### PR TITLE
fluentd 経由で slack 通知ができるようにする

### DIFF
--- a/.chef/knife.rb
+++ b/.chef/knife.rb
@@ -3,7 +3,7 @@ node_path        "nodes"
 role_path        "roles"
 environment_path "environments"
 data_bag_path    "./data_bags"
-encrypted_data_bag_secret "./secure/data_bag_key"
+encrypted_data_bag_secret "data_bag_key"
 
 knife[:berkshelf_path] = "cookbooks"
 Chef::Config[:ssl_verify_mode] = :verify_peer if defined? ::Chef

--- a/.chef/knife.rb
+++ b/.chef/knife.rb
@@ -2,8 +2,8 @@ cookbook_path    ["cookbooks", "site-cookbooks"]
 node_path        "nodes"
 role_path        "roles"
 environment_path "environments"
-data_bag_path    "data_bags"
-#encrypted_data_bag_secret "data_bag_key"
+data_bag_path    "./data_bags"
+encrypted_data_bag_secret "./secure/data_bag_key"
 
 knife[:berkshelf_path] = "cookbooks"
 Chef::Config[:ssl_verify_mode] = :verify_peer if defined? ::Chef

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 /.vagrant
 /vendor/bundle
 /cookbooks/
-/secure
+data_bag_key

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /.vagrant
 /vendor/bundle
 /cookbooks/
+/secure

--- a/circle.yml
+++ b/circle.yml
@@ -22,6 +22,7 @@ dependencies:
       fi
       cd ~/$CIRCLE_PROJECT_REPONAME
       echo $GCP_KEY > $GCP_KEY_LOCATION
+      sudo echo -e $DATA_BAG_KEY > data_bag_key
 test:
   pre:
     - vagrant up gcp --provider=google

--- a/data_bags/webhook_urls/knock.json
+++ b/data_bags/webhook_urls/knock.json
@@ -1,0 +1,9 @@
+{
+  "id": "knock",
+  "slack": {
+    "encrypted_data": "W20L8VqSyJEjAir0jpbwT8auZt5zCDcLAgu8rLZvMuQ1eEi7xzmRqAi11GcD\nqRffYB8FyEn/j1UEawEe5wwiEgyRPBk88JVhiSDFRthoBAfAoZyUoAOGNlWO\nycdP8Iq3jQUjQvTSkrP1eMnopS2D/w==\n",
+    "iv": "87afLW+TSx77435FLue4aQ==\n",
+    "version": 1,
+    "cipher": "aes-256-cbc"
+  }
+}

--- a/roles/base.json
+++ b/roles/base.json
@@ -23,7 +23,7 @@
     "recipe[ruby]",
     "recipe[selinux::permissive]",
     "recipe[sudoers]",
-    "recipe[td-agent]",
+    "recipe[td-agent::setting]",
     "recipe[timezone]",
     "recipe[zlib::devel]"
   ]

--- a/site-cookbooks/td-agent/recipes/setting.rb
+++ b/site-cookbooks/td-agent/recipes/setting.rb
@@ -1,0 +1,14 @@
+include_recipe 'td-agent'
+
+%w(fluent-plugin-slack).each do |gem|
+  gem_package gem do
+    gem_binary '/opt/td-agent/embedded/bin/fluent-gem'
+    notifies :restart, 'service[td-agent]'
+  end
+end
+
+template '/etc/td-agent/td-agent.conf' do
+  variables knock_url: nil
+  source 'td-agent.conf.erb'
+  notifies :restart, 'service[td-agent]'
+end

--- a/site-cookbooks/td-agent/recipes/setting.rb
+++ b/site-cookbooks/td-agent/recipes/setting.rb
@@ -1,4 +1,6 @@
 include_recipe 'td-agent'
+data_bag = Chef::EncryptedDataBagItem.load('webhook_urls', 'knock')
+
 
 %w(fluent-plugin-slack).each do |gem|
   gem_package gem do
@@ -8,7 +10,7 @@ include_recipe 'td-agent'
 end
 
 template '/etc/td-agent/td-agent.conf' do
-  variables knock_url: nil
+  variables knock_url: data_bag['slack']
   source 'td-agent.conf.erb'
   notifies :restart, 'service[td-agent]'
 end

--- a/site-cookbooks/td-agent/templates/default/td-agent.conf.erb
+++ b/site-cookbooks/td-agent/templates/default/td-agent.conf.erb
@@ -1,0 +1,14 @@
+<source>
+  type forward
+</source>
+
+<match knock.slack>
+  type slack
+  webhook_url <%= @knock_url %>
+  channel a-know-home-notify
+  username VisitorNotification
+  icon_emoji :wind_chime:
+  flush_interval 10s
+</match>
+
+@include conf.d/*.conf

--- a/spec/shared/td-agent.rb
+++ b/spec/shared/td-agent.rb
@@ -7,4 +7,18 @@ shared_examples 'td-agent' do
     it { should be_enabled }
     it { should be_running }
   end
+
+  describe file '/etc/td-agent/td-agent.conf' do
+    it { should be_owned_by 'root' }
+    it { should be_grouped_into 'root' }
+    it { should be_mode 644 }
+    its(:content) { should include '@include conf.d/*.conf' }
+  end
+
+  describe 'Plugins' do
+    let(:path) { "/opt/td-agent/embedded/bin:#{ENV['PATH']}" }
+    describe package 'fluent-plugin-slack' do
+      it { should be_installed.by('gem') }
+    end
+  end
 end


### PR DESCRIPTION
#### やりたいこと
* `a-know-home` にアクセスがあったら、そのことを slack で通知したい
    * 現状、数人/日 なアクセス数なので、毎回で良い

#### やったこと
* for fluentd な conf ファイルの作成
* slack 通知用の fluent gem のインストール
* webhook url を Encrypted DataBag を使って暗号化
    * http://blog.cloudpack.jp/2014/12/16/use-aws-credential-information-with-chef-unavoidably/