### PR TITLE
証明書の更新を行うコマンドを cron に叩かせたい

### DIFF
--- a/roles/prod.json
+++ b/roles/prod.json
@@ -4,6 +4,7 @@
   "json_class": "Chef::Role",
 
   "run_list": [
+    "recipe[crontab]",
     "recipe[mackerel]",
     "recipe[mkswap]"
   ]

--- a/site-cookbooks/crontab/recipes/default.rb
+++ b/site-cookbooks/crontab/recipes/default.rb
@@ -1,0 +1,9 @@
+include_recipe 'crond'
+
+cron "Refresh Let's Encrypt cert-file and restart nginx" do
+  user 'root'
+  command '/usr/local/letsencrypt/letsencrypt-auto certonly --webroot -w /var/www/a-know-home/current/public -d home.a-know.me --renew-by-default && sudo nginx -s reload'
+  day '15'
+  hour '4'
+  minute '00'
+end

--- a/spec/roles/web_prod_spec.rb
+++ b/spec/roles/web_prod_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe 'web' do
   it_behaves_like 'chrony'
+  it_behaves_like 'crontab'
   it_behaves_like 'firewalld::disable'
   it_behaves_like 'gcc'
   it_behaves_like 'git'

--- a/spec/shared/crontab.rb
+++ b/spec/shared/crontab.rb
@@ -1,0 +1,5 @@
+shared_examples 'crontab' do
+  describe cron do
+    it { should have_entry('00 4 15 * * /usr/local/letsencrypt/letsencrypt-auto certonly --webroot -w /var/www/a-know-home/current/public -d home.a-know.me --renew-by-default && sudo nginx -s reload').with_user('root') }
+  end
+end


### PR DESCRIPTION
事前検証などは #38 参照。

chef recipe の cron リソースで、root の crontab に設定してしまう。