### PR TITLE
a-know ユーザの作成

### DIFF
--- a/data_bags/users/a-know.json
+++ b/data_bags/users/a-know.json
@@ -1,0 +1,11 @@
+{
+  "id": "a-know",
+  "uid": "a-know",
+  "gid": "a-know",
+  "password": "$6$T068FNlrpdI/zpVd$6jxpwiq2fqW3uKzFW1kIOHhDeUavaqwZ.5MJDYqw.Lhd6sP2IHhbOuJQiVFiMK8pioFpb5dY624PUSAXYGZgD1",
+  "home": "/home/a-know",
+  "shell": "/bin/bash",
+  "authorized_keys": [
+    "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC/ZZ0rIx+tWsWi7GbFZYkbUkQascXY5p9K/DKx3vRqANXp4YNkqLlkhI2oJIfMCcjWoUJI1aZSOp+T9hx5jo/R46EnzZAtAnzXENgK9sqolJk08bTGOaGOqIKUk7i+HXVet8CEUiv6xczuo61zZYrjr0TmVZAmPY03fiFpt6YJ+oDiv9aKkDhzFiPjnIP0pq1gxVu4deyA4/oPYkpJFxmbphF+0BjCViaStSGmQfZH7W6TqUGJ2QJVi3xC86PbYjZven/8phNbSS9ief+P62mFz9CfLmseCMIg3NiSFi19DrxqMgYYfIcfI6MbOdG/SWp04Fwg82Mx54uylUrLKQxt a-know@a-know-no-MacBook-Pro.local"
+  ]
+}

--- a/nodes/ci-web.json
+++ b/nodes/ci-web.json
@@ -3,6 +3,7 @@
     "hostname": "ci-centrage"
   },
   "run_list": [
-    "role[base]"
+    "role[base]",
+    "role[vm]"
   ]
 }

--- a/nodes/vm-web.json
+++ b/nodes/vm-web.json
@@ -3,6 +3,7 @@
     "hostname": "vm-centrage"
   },
   "run_list": [
-    "role[base]"
+    "role[base]",
+    "role[vm]"
   ]
 }

--- a/roles/vm.json
+++ b/roles/vm.json
@@ -1,0 +1,9 @@
+{
+  "name": "vm",
+  "description": "vm role",
+  "json_class": "Chef::Role",
+
+  "run_list": [
+    "recipe[users]"
+  ]
+}

--- a/site-cookbooks/users/recipes/default.rb
+++ b/site-cookbooks/users/recipes/default.rb
@@ -1,0 +1,47 @@
+data_ids = data_bag('users')
+
+groups = {}
+
+data_ids.each do |id|
+  u = data_bag_item('users', id)
+  user u['uid'] do
+    gid u['gid']# unless u['uid'] == u['gid']
+    password u['password']
+    home u['home']
+    shell u['shell']
+  end
+
+  (u['groups'] || []).each do |name|
+    groups[name] ||= []
+    groups[name] << u['uid']
+  end
+
+  directory u['home'] do
+    mode 0755
+    action :create
+  end
+
+  next unless u['authorized_keys']
+
+  directory "#{u['home']}/.ssh" do
+    owner u['uid']
+    group u['gid']
+    mode 0755
+    action :create
+  end
+
+  file "#{u['home']}/.ssh/authorized_keys" do
+    content u['authorized_keys'].join("\n")
+    owner u['uid']
+    group u['gid']
+    mode 0600
+    action :create
+  end
+end
+
+groups.each do |name, members|
+  group name do
+    members members
+    action :manage
+  end
+end

--- a/site-cookbooks/users/recipes/default.rb
+++ b/site-cookbooks/users/recipes/default.rb
@@ -5,7 +5,7 @@ groups = {}
 data_ids.each do |id|
   u = data_bag_item('users', id)
   user u['uid'] do
-    gid u['gid']# unless u['uid'] == u['gid']
+    gid u['gid'] unless u['uid'] == u['gid']
     password u['password']
     home u['home']
     shell u['shell']

--- a/spec/roles/web_base_spec.rb
+++ b/spec/roles/web_base_spec.rb
@@ -16,5 +16,6 @@ describe 'web' do
   it_behaves_like 'sudoers'
   it_behaves_like 'td-agent'
   it_behaves_like 'timezone'
+  it_behaves_like 'users'
   it_behaves_like 'zlib'
 end

--- a/spec/roles/web_prod_spec.rb
+++ b/spec/roles/web_prod_spec.rb
@@ -19,5 +19,6 @@ describe 'web' do
   it_behaves_like 'sudoers'
   it_behaves_like 'td-agent'
   it_behaves_like 'timezone'
+  it_behaves_like 'users'
   it_behaves_like 'zlib'
 end

--- a/spec/shared/users.rb
+++ b/spec/shared/users.rb
@@ -1,0 +1,35 @@
+shared_examples 'users' do
+  describe 'a-know' do
+    let(:user) { 'a-know' }
+
+    describe user 'a-know' do
+      it { should exist }
+      it { should belong_to_group 'a-know' }
+
+      it 'should have authorized key of a-know' do
+        should have_authorized_key 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC/ZZ0rIx+tWsWi7GbFZYkbUkQascXY5p9K/DKx3vRqANXp4YNkqLlkhI2oJIfMCcjWoUJI1aZSOp+T9hx5jo/R46EnzZAtAnzXENgK9sqolJk08bTGOaGOqIKUk7i+HXVet8CEUiv6xczuo61zZYrjr0TmVZAmPY03fiFpt6YJ+oDiv9aKkDhzFiPjnIP0pq1gxVu4deyA4/oPYkpJFxmbphF+0BjCViaStSGmQfZH7W6TqUGJ2QJVi3xC86PbYjZven/8phNbSS9ief+P62mFz9CfLmseCMIg3NiSFi19DrxqMgYYfIcfI6MbOdG/SWp04Fwg82Mx54uylUrLKQxt a-know@a-know-no-MacBook-Pro.local'
+      end
+    end
+
+    describe file '/home/a-know' do
+      it { should be_directory }
+      it { should be_owned_by 'a-know' }
+      it { should be_grouped_into 'a-know' }
+      # it { should be_mode 755 } # GCP により作成されたばあいは 700
+    end
+
+    describe file '/home/a-know/.ssh' do
+      it { should be_directory }
+      it { should be_owned_by 'a-know' }
+      it { should be_grouped_into 'a-know' }
+      # it { should be_mode 755 } # GCP により作成されたばあいは 700
+    end
+
+    describe file '/home/a-know/.ssh/authorized_keys' do
+      it { should be_file }
+      it { should be_owned_by 'a-know' }
+      it { should be_grouped_into 'a-know' }
+      it { should be_mode 600 }
+    end
+  end
+end


### PR DESCRIPTION
GCP のメタデータに設定している場合は a-know ユーザは自動で作成されるが、
vm の場合には作成されないため、vm のときだけ作成するレシピを作成。

perl 環境の整備時に a-know ユーザがあったほうがよい。