### PR TITLE
[WIP] 証明書のダミーを置いてみる

### DIFF
--- a/site-cookbooks/letsencrypt/files/cert1.pem
+++ b/site-cookbooks/letsencrypt/files/cert1.pem
@@ -1,0 +1,3 @@
+-----BEGIN CERTIFICATE-----
+cert-dummy
+-----END CERTIFICATE-----

--- a/site-cookbooks/letsencrypt/files/chain1.pem
+++ b/site-cookbooks/letsencrypt/files/chain1.pem
@@ -1,0 +1,3 @@
+-----BEGIN CERTIFICATE-----
+chain-dummy
+-----END CERTIFICATE-----

--- a/site-cookbooks/letsencrypt/files/fullchain1.pem
+++ b/site-cookbooks/letsencrypt/files/fullchain1.pem
@@ -1,0 +1,6 @@
+-----BEGIN CERTIFICATE-----
+fullchain_dummy
+-----END CERTIFICATE-----
+-----BEGIN CERTIFICATE-----
+fullchain_dummy
+-----END CERTIFICATE-----

--- a/site-cookbooks/letsencrypt/files/privkey1.pem
+++ b/site-cookbooks/letsencrypt/files/privkey1.pem
@@ -1,0 +1,3 @@
+-----BEGIN PRIVATE KEY-----
+privkey_dummy
+-----END PRIVATE KEY-----

--- a/site-cookbooks/letsencrypt/recipes/default.rb
+++ b/site-cookbooks/letsencrypt/recipes/default.rb
@@ -53,3 +53,25 @@ cookbook_file '/etc/letsencrypt/archive/home.a-know.me/privkey1.pem' do
   mode     0644
   source   'privkey1.pem'
 end
+
+directory '/etc/letsencrypt/live' do
+  owner 'root'
+  group 'root'
+  mode  0700
+  action :create
+end
+
+directory '/etc/letsencrypt/live/home.a-know.me' do
+  owner 'root'
+  group 'root'
+  mode  0755
+  action :create
+end
+
+link "/etc/letsencrypt/live/home.a-know.me/fullchain.pem" do
+  to "/etc/letsencrypt/archive/home.a-know.me/fullchain1.pem"
+end
+
+link "/etc/letsencrypt/live/home.a-know.me/privkey.pem" do
+  to "/etc/letsencrypt/archive/home.a-know.me/privkey1.pem"
+end

--- a/site-cookbooks/letsencrypt/recipes/default.rb
+++ b/site-cookbooks/letsencrypt/recipes/default.rb
@@ -4,3 +4,52 @@ git '/usr/local/letsencrypt' do
   repository 'https://github.com/letsencrypt/letsencrypt'
   action :checkout
 end
+
+directory '/etc/letsencrypt' do
+  owner 'root'
+  group 'root'
+  mode  0755
+  action :create
+end
+
+directory '/etc/letsencrypt/archive' do
+  owner 'root'
+  group 'root'
+  mode  0700
+  action :create
+end
+
+directory '/etc/letsencrypt/archive/home.a-know.me' do
+  owner 'root'
+  group 'root'
+  mode  0755
+  action :create
+end
+
+cookbook_file '/etc/letsencrypt/archive/home.a-know.me/cert1.pem' do
+  user     'root'
+  group    'root'
+  mode     0644
+  source   'cert1.pem'
+end
+
+cookbook_file '/etc/letsencrypt/archive/home.a-know.me/chain1.pem' do
+  user     'root'
+  group    'root'
+  mode     0644
+  source   'chain1.pem'
+end
+
+cookbook_file '/etc/letsencrypt/archive/home.a-know.me/fullchain1.pem' do
+  user     'root'
+  group    'root'
+  mode     0644
+  source   'fullchain1.pem'
+end
+
+cookbook_file '/etc/letsencrypt/archive/home.a-know.me/privkey1.pem' do
+  user     'root'
+  group    'root'
+  mode     0644
+  source   'privkey1.pem'
+end

--- a/spec/shared/letsencrypt.rb
+++ b/spec/shared/letsencrypt.rb
@@ -5,4 +5,32 @@ shared_examples 'letsencrypt' do
     it { should be_grouped_into 'root' }
     it { should be_mode 755 }
   end
+
+  describe file '/etc/letsencrypt/archive/home.a-know.me/cert1.pem' do
+    it { should be_file }
+    it { should be_owned_by 'root' }
+    it { should be_grouped_into 'root' }
+    it { should be_mode 644 }
+  end
+
+  describe file '/etc/letsencrypt/archive/home.a-know.me/chain1.pem' do
+    it { should be_file }
+    it { should be_owned_by 'root' }
+    it { should be_grouped_into 'root' }
+    it { should be_mode 644 }
+  end
+
+  describe file '/etc/letsencrypt/archive/home.a-know.me/fullchain1.pem' do
+    it { should be_file }
+    it { should be_owned_by 'root' }
+    it { should be_grouped_into 'root' }
+    it { should be_mode 644 }
+  end
+
+  describe file '/etc/letsencrypt/archive/home.a-know.me/privkey1.pem' do
+    it { should be_file }
+    it { should be_owned_by 'root' }
+    it { should be_grouped_into 'root' }
+    it { should be_mode 644 }
+  end
 end


### PR DESCRIPTION
Let's Encrypt 対応により、nginx の conf に常に証明書ファイルを指定する形となったが、
証明書ファイルが無い場合はエラーとなってしまう（起動もできない？）。

これを、ダミーファイルを配置することで対処できないか？試してみる。