### PR TITLE
Nginxのアクセスログからステータスコード毎にリクエスト数を Mackerel サービスメトリックに投稿する

### DIFF
--- a/site-cookbooks/nginx/files/default/nginx.conf
+++ b/site-cookbooks/nginx/files/default/nginx.conf
@@ -23,6 +23,8 @@ http {
                       "\treferer:$http_referer"
                       "\tua:$http_user_agent"
                       "\treqtime:$request_time"
+                      "\tcache:$upstream_http_x_cache"
+                      "\truntime:$upstream_http_x_runtime"
                       "\tvhost:$host";
 
     access_log  /var/log/nginx/access.log  ltsv;

--- a/site-cookbooks/td-agent/attributes/default.rb
+++ b/site-cookbooks/td-agent/attributes/default.rb
@@ -1,0 +1,1 @@
+default['mackerel']['apikey'] = nil

--- a/site-cookbooks/td-agent/recipes/setting.rb
+++ b/site-cookbooks/td-agent/recipes/setting.rb
@@ -2,7 +2,7 @@ include_recipe 'td-agent'
 data_bag = Chef::EncryptedDataBagItem.load('webhook_urls', 'knock')
 
 
-%w(fluent-plugin-slack).each do |gem|
+%w(fluent-plugin-slack fluentd-plugin-mackerel).each do |gem|
   gem_package gem do
     gem_binary '/opt/td-agent/embedded/bin/fluent-gem'
     notifies :restart, 'service[td-agent]'

--- a/site-cookbooks/td-agent/recipes/setting.rb
+++ b/site-cookbooks/td-agent/recipes/setting.rb
@@ -3,7 +3,7 @@ data_bag = Chef::EncryptedDataBagItem.load('webhook_urls', 'knock')
 mackerel_credentials = Chef::EncryptedDataBagItem.load('credentials', 'mackerel')
 
 
-%w(fluent-plugin-slack fluentd-plugin-mackerel fluent-plugin-datacounter).each do |gem|
+%w(fluent-plugin-slack fluent-plugin-mackerel fluent-plugin-datacounter).each do |gem|
   gem_package gem do
     gem_binary '/opt/td-agent/embedded/bin/fluent-gem'
     notifies :restart, 'service[td-agent]'

--- a/site-cookbooks/td-agent/recipes/setting.rb
+++ b/site-cookbooks/td-agent/recipes/setting.rb
@@ -1,5 +1,6 @@
 include_recipe 'td-agent'
 data_bag = Chef::EncryptedDataBagItem.load('webhook_urls', 'knock')
+mackerel_credentials = Chef::EncryptedDataBagItem.load('credentials', 'mackerel')
 
 
 %w(fluent-plugin-slack fluentd-plugin-mackerel fluent-plugin-datacounter).each do |gem|
@@ -12,5 +13,14 @@ end
 template '/etc/td-agent/td-agent.conf' do
   variables knock_url: data_bag['slack']
   source 'td-agent.conf.erb'
+  notifies :restart, 'service[td-agent]'
+end
+
+directory '/etc/td-agent/conf.d'
+
+template '/etc/td-agent/conf.d/nginx_access_log.conf' do
+  variables mackerel_api_key: mackerel_credentials['api_key']
+  variables mackerel_service_name: 'a-know-home'
+  source 'nginx_access_log.conf.erb'
   notifies :restart, 'service[td-agent]'
 end

--- a/site-cookbooks/td-agent/recipes/setting.rb
+++ b/site-cookbooks/td-agent/recipes/setting.rb
@@ -2,7 +2,7 @@ include_recipe 'td-agent'
 data_bag = Chef::EncryptedDataBagItem.load('webhook_urls', 'knock')
 
 
-%w(fluent-plugin-slack fluentd-plugin-mackerel).each do |gem|
+%w(fluent-plugin-slack fluentd-plugin-mackerel fluent-plugin-datacounter).each do |gem|
   gem_package gem do
     gem_binary '/opt/td-agent/embedded/bin/fluent-gem'
     notifies :restart, 'service[td-agent]'

--- a/site-cookbooks/td-agent/recipes/setting.rb
+++ b/site-cookbooks/td-agent/recipes/setting.rb
@@ -19,8 +19,7 @@ end
 directory '/etc/td-agent/conf.d'
 
 template '/etc/td-agent/conf.d/nginx_access_log.conf' do
-  variables mackerel_api_key: mackerel_credentials['api_key']
-  variables mackerel_service_name: 'a-know-home'
+  variables mackerel_api_key: mackerel_credentials['api_key'], mackerel_service_name: 'a-know-home'
   source 'nginx_access_log.conf.erb'
   notifies :restart, 'service[td-agent]'
 end

--- a/site-cookbooks/td-agent/templates/default/nginx_access_log.conf.erb
+++ b/site-cookbooks/td-agent/templates/default/nginx_access_log.conf.erb
@@ -4,7 +4,7 @@
   format ltsv
   time_format %d/%b/%Y:%H:%M:%S %z
   path /var/log/nginx/home.a-know.me.access.log
-  pos_file /var/log/nginx/home.a-know.me.access_log.pos
+  pos_file /var/log/td-agent/home.a-know.me.access_log.pos
   tag access.nginx
 </source>
 

--- a/site-cookbooks/td-agent/templates/default/nginx_access_log.conf.erb
+++ b/site-cookbooks/td-agent/templates/default/nginx_access_log.conf.erb
@@ -1,0 +1,32 @@
+# LTSV形式のログファイルを読み込む
+<source>
+  type tail
+  format ltsv
+  time_format %d/%b/%Y:%H:%M:%S %z
+  path /var/log/nginx/access.log
+  pos_file /var/log/nginx/access_log.pos
+  tag access.nginx
+</source>
+
+# fluent-plugin-datacounterでステータスコード別に集計する
+<match access.nginx>
+  type datacounter
+  count_interval 1m
+  count_key status
+  aggregate all
+  tag nginx.status
+  pattern1 2xx ^2\d\d$
+  pattern2 3xx ^3\d\d$
+  pattern3 4xx ^4\d\d$
+  pattern4 5xx ^5\d\d$
+</match>
+
+# fluent-plugin-mackerelによりサービスメトリックを投稿する
+<match nginx.status.**>
+  type mackerel
+  api_key <%= @mackerel_api_key %>
+  service <%= @mackerel_service_name %>
+  remove_prefix
+  metrics_name access_num.${out_key}
+  out_keys 2xx_count,3xx_count,4xx_count,5xx_count
+</match>

--- a/site-cookbooks/td-agent/templates/default/nginx_access_log.conf.erb
+++ b/site-cookbooks/td-agent/templates/default/nginx_access_log.conf.erb
@@ -3,8 +3,8 @@
   type tail
   format ltsv
   time_format %d/%b/%Y:%H:%M:%S %z
-  path /var/log/nginx/access.log
-  pos_file /var/log/nginx/access_log.pos
+  path /var/log/nginx/home.a-know.me.access.log
+  pos_file /var/log/nginx/home.a-know.me.access_log.pos
   tag access.nginx
 </source>
 

--- a/site-cookbooks/td-agent/templates/default/td-agent.conf.erb
+++ b/site-cookbooks/td-agent/templates/default/td-agent.conf.erb
@@ -11,4 +11,4 @@
   flush_interval 10s
 </match>
 
-@include conf.d/*.conf
+@include /etc/td-agent/conf.d/*.conf

--- a/spec/shared/td-agent.rb
+++ b/spec/shared/td-agent.rb
@@ -12,7 +12,13 @@ shared_examples 'td-agent' do
     it { should be_owned_by 'root' }
     it { should be_grouped_into 'root' }
     it { should be_mode 644 }
-    its(:content) { should include '@include conf.d/*.conf' }
+    its(:content) { should include '@include /etc/td-agent/conf.d/*.conf' }
+  end
+
+  describe file '/etc/td-agent/conf.d/nginx_access_log.conf' do
+    it { should be_owned_by 'root' }
+    it { should be_grouped_into 'root' }
+    it { should be_mode 644 }
   end
 
   describe 'Plugins' do

--- a/spec/shared/td-agent.rb
+++ b/spec/shared/td-agent.rb
@@ -27,7 +27,7 @@ shared_examples 'td-agent' do
       it { should be_installed.by('gem') }
     end
 
-    describe package 'fluentd-plugin-mackerel' do
+    describe package 'fluent-plugin-mackerel' do
       it { should be_installed.by('gem') }
     end
 

--- a/spec/shared/td-agent.rb
+++ b/spec/shared/td-agent.rb
@@ -20,5 +20,9 @@ shared_examples 'td-agent' do
     describe package 'fluent-plugin-slack' do
       it { should be_installed.by('gem') }
     end
+
+    describe package 'fluentd-plugin-mackerel' do
+      it { should be_installed.by('gem') }
+    end
   end
 end

--- a/spec/shared/td-agent.rb
+++ b/spec/shared/td-agent.rb
@@ -24,5 +24,9 @@ shared_examples 'td-agent' do
     describe package 'fluentd-plugin-mackerel' do
       it { should be_installed.by('gem') }
     end
+
+    describe package 'fluent-plugin-datacounter' do
+      it { should be_installed.by('gem') }
+    end
   end
 end


### PR DESCRIPTION
#49 。
http://help-ja.mackerel.io/entry/advanced/fluentd#example-nginx これ。