### PR TITLE
`grass-graph.shitemil.works` を同一サーバインスタンスでホストする

### DIFF
--- a/site-cookbooks/crontab/recipes/default.rb
+++ b/site-cookbooks/crontab/recipes/default.rb
@@ -1,9 +1,17 @@
 include_recipe 'crond'
 
-cron "Refresh Let's Encrypt cert-file and restart nginx" do
+cron "Refresh Let's Encrypt cert-file (for home.a-know.me) and restart nginx" do
   user 'root'
   command '/usr/local/letsencrypt/letsencrypt-auto certonly --webroot -w /var/www/a-know-home/current/public -d home.a-know.me --renew-by-default && sudo nginx -s reload'
   day '15'
+  hour '4'
+  minute '00'
+end
+
+cron "Refresh Let's Encrypt cert-file (for grass-graph.shitemil.works) and restart nginx" do
+  user 'root'
+  command '/usr/local/letsencrypt/letsencrypt-auto certonly --webroot -w /var/www/a-know-home/current/public/gglp -d grass-graph.shitemil.works --renew-by-default && sudo nginx -s reload'
+  day '10'
   hour '4'
   minute '00'
 end

--- a/site-cookbooks/nginx/recipes/default.rb
+++ b/site-cookbooks/nginx/recipes/default.rb
@@ -29,4 +29,11 @@ template '/etc/nginx/conf.d/home.a-know.me.conf' do
   notifies :reload, 'service[nginx]'
 end
 
+template '/etc/nginx/conf.d/grass-graph.shitemil.works.conf' do
+  user     'root'
+  group    'root'
+  mode     0644
+  notifies :reload, 'service[nginx]'
+end
+
 include_recipe 'nginx::logrotate'

--- a/site-cookbooks/nginx/templates/default/grass-graph.shitemil.works.conf.erb
+++ b/site-cookbooks/nginx/templates/default/grass-graph.shitemil.works.conf.erb
@@ -1,0 +1,32 @@
+upstream gg_unicorn {
+  server unix:/var/www/a-know-home/current/tmp/sockets/unicorn.socket;
+}
+
+server {
+    listen       80;
+    server_name  grass-graph.shitemil.works;
+
+    root /var/www/a-know-home/current/public/gglp;
+
+    access_log /var/log/nginx/grass-graph.shitemil.works.access.log ltsv;
+    error_log  /var/log/nginx/grass-graph.shitemil.works.error.log;
+
+    location / {
+      try_files $uri $uri/index.html $uri.html @gg_unicorn;
+    }
+
+    location ~ .*\.(json|js|html|less|css|eot|svg|ttf|woff|otf|scss|txt|jpg|png|gif|map|ico) {
+      root /var/www/a-know-home/current/public/gglp;
+    }
+
+    location @gg_unicorn {
+      satisfy any;
+      allow   all;
+      proxy_pass http://gg_unicorn;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+      proxy_set_header Host $http_host;
+      proxy_redirect off;
+    }
+}

--- a/site-cookbooks/nginx/templates/default/grass-graph.shitemil.works.conf.erb
+++ b/site-cookbooks/nginx/templates/default/grass-graph.shitemil.works.conf.erb
@@ -4,7 +4,15 @@ upstream gg_unicorn {
 
 server {
     listen       80;
+    listen       443 ssl;
     server_name  grass-graph.shitemil.works;
+
+    ssl_certificate /etc/letsencrypt/live/grass-graph.shitemil.works/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/grass-graph.shitemil.works/privkey.pem;
+
+    ssl_session_cache   shared:SSL:3m;
+    ssl_buffer_size     8k;
+    ssl_session_timeout 10m;
 
     root /var/www/a-know-home/current/public/gglp;
 

--- a/site-cookbooks/nginx/templates/default/home.a-know.me.conf.erb
+++ b/site-cookbooks/nginx/templates/default/home.a-know.me.conf.erb
@@ -3,7 +3,7 @@ upstream unicorn {
 }
 
 server {
-    listen       80;
+    listen       80 default_server;
     listen       443 ssl;
     server_name  home.a-know.me;
 

--- a/spec/shared/crontab.rb
+++ b/spec/shared/crontab.rb
@@ -1,5 +1,6 @@
 shared_examples 'crontab' do
   describe cron do
     it { should have_entry('00 4 15 * * /usr/local/letsencrypt/letsencrypt-auto certonly --webroot -w /var/www/a-know-home/current/public -d home.a-know.me --renew-by-default && sudo nginx -s reload').with_user('root') }
+    it { should have_entry('00 4 10 * * /usr/local/letsencrypt/letsencrypt-auto certonly --webroot -w /var/www/a-know-home/current/public/gglp -d grass-graph.shitemil.works --renew-by-default && sudo nginx -s reload').with_user('root') }
   end
 end

--- a/spec/shared/nginx.rb
+++ b/spec/shared/nginx.rb
@@ -19,6 +19,14 @@ shared_examples 'nginx' do
     its(:content) { should include '80 default_server' }
   end
 
+  describe file '/etc/nginx/conf.d/grass-graph.shitemil.works.conf' do
+    it { should be_file }
+    it { should be_owned_by 'root' }
+    it { should be_grouped_into 'root' }
+    it { should be_mode 644 }
+    its(:content) { should match /listen\s+80;/ } # not default server
+  end
+
   describe file '/etc/logrotate.d/nginx' do
     it { should be_file }
     it { should be_owned_by 'root' }

--- a/spec/shared/nginx.rb
+++ b/spec/shared/nginx.rb
@@ -16,6 +16,7 @@ shared_examples 'nginx' do
     it { should be_owned_by 'root' }
     it { should be_grouped_into 'root' }
     it { should be_mode 644 }
+    its(:content) { should include '80 default_server' }
   end
 
   describe file '/etc/logrotate.d/nginx' do


### PR DESCRIPTION
バーチャルホスト設定する。

画像を表示させるためのバックエンド（unicorn プロセス）は、 home.a-know.me に相乗りする。


#### ゴール
* [x] `grass-graph.shitemil.works` にアクセスしたら https://github.com/a-know/a-know-home-rails/pull/60 で用意した Grass-Graph のトップページが表示されること
* [x] `grass-graph.shitemil,works/images/{github_id}` にアクセスしたら、その github id のグラフ画像が取得できること
* [x] https でアクセスできるようにすること
* [x] `grass-graph.shitemil.works` 用の SSL 証明書の自動更新スケジュールを crontab にセットしていること