### PR TITLE
Enable to specify extname for grass-graph

### DIFF
--- a/site-cookbooks/nginx/templates/default/grass-graph.shitemil.works.conf.erb
+++ b/site-cookbooks/nginx/templates/default/grass-graph.shitemil.works.conf.erb
@@ -23,6 +23,10 @@ server {
       try_files $uri $uri/index.html $uri.html @gg_unicorn;
     }
 
+    location ~ /images/.+\.png {
+      try_files $uri $uri/index.html $uri.html @gg_unicorn;
+    }
+
     location ~ .*\.(json|js|html|less|css|eot|svg|ttf|woff|otf|scss|txt|jpg|png|gif|map|ico) {
       root /var/www/a-know-home/current/public/gglp;
     }


### PR DESCRIPTION
https://github.com/a-know/a-know-home-rails/issues/78 に関連。

拡張子を指定すれば twitter cards でも表示できるのではないかと考えて対応してみる。