### PR TITLE
Let's encrypt の認証用ファイルの設置場所を変更する

### DIFF
--- a/site-cookbooks/crontab/recipes/default.rb
+++ b/site-cookbooks/crontab/recipes/default.rb
@@ -2,7 +2,7 @@ include_recipe 'crond'
 
 cron "Refresh Let's Encrypt cert-file (for home.a-know.me) and restart nginx" do
   user 'root'
-  command '/usr/local/letsencrypt/letsencrypt-auto certonly --webroot -w /var/www/a-know-home/current/public -d home.a-know.me --renew-by-default && sudo nginx -s reload'
+  command '/usr/local/letsencrypt/letsencrypt-auto certonly --webroot -w /var/www/a-know-home/shared/public -d home.a-know.me --renew-by-default && sudo nginx -s reload'
   day '15'
   hour '4'
   minute '00'
@@ -10,7 +10,7 @@ end
 
 cron "Refresh Let's Encrypt cert-file (for grass-graph.shitemil.works) and restart nginx" do
   user 'root'
-  command '/usr/local/letsencrypt/letsencrypt-auto certonly --webroot -w /var/www/a-know-home/current/public/gglp -d grass-graph.shitemil.works --renew-by-default && sudo nginx -s reload'
+  command '/usr/local/letsencrypt/letsencrypt-auto certonly --webroot -w /var/www/a-know-home/shared/public -d grass-graph.shitemil.works --renew-by-default && sudo nginx -s reload'
   day '10'
   hour '4'
   minute '00'

--- a/site-cookbooks/nginx/templates/default/grass-graph.shitemil.works.conf.erb
+++ b/site-cookbooks/nginx/templates/default/grass-graph.shitemil.works.conf.erb
@@ -31,6 +31,11 @@ server {
 
     add_header Strict-Transport-Security "max-age=2592000; includeSubdomains";
 
+    location /.well-known {
+      default_type "text/plain";
+      root /var/www/a-know-home/shared/public;
+    }
+
     location / {
       try_files $uri $uri/index.html $uri.html @gg_unicorn;
     }

--- a/site-cookbooks/nginx/templates/default/home.a-know.me.conf.erb
+++ b/site-cookbooks/nginx/templates/default/home.a-know.me.conf.erb
@@ -29,6 +29,11 @@ server {
     access_log /var/log/nginx/home.a-know.me.access.log ltsv;
     error_log  /var/log/nginx/home.a-know.me.error.log;
 
+    location /.well-known {
+      default_type "text/plain";
+      root /var/www/a-know-home/shared/public;
+    }
+
     location ~ /(webdav|muieblackcat|manager/html|cgi-bin) {
       deny all;
     }

--- a/spec/shared/crontab.rb
+++ b/spec/shared/crontab.rb
@@ -1,6 +1,6 @@
 shared_examples 'crontab' do
   describe cron do
-    it { should have_entry('00 4 15 * * /usr/local/letsencrypt/letsencrypt-auto certonly --webroot -w /var/www/a-know-home/current/public -d home.a-know.me --renew-by-default && sudo nginx -s reload').with_user('root') }
-    it { should have_entry('00 4 10 * * /usr/local/letsencrypt/letsencrypt-auto certonly --webroot -w /var/www/a-know-home/current/public/gglp -d grass-graph.shitemil.works --renew-by-default && sudo nginx -s reload').with_user('root') }
+    it { should have_entry('00 4 15 * * /usr/local/letsencrypt/letsencrypt-auto certonly --webroot -w /var/www/a-know-home/shared/public -d home.a-know.me --renew-by-default && sudo nginx -s reload').with_user('root') }
+    it { should have_entry('00 4 10 * * /usr/local/letsencrypt/letsencrypt-auto certonly --webroot -w /var/www/a-know-home/shared/public -d grass-graph.shitemil.works --renew-by-default && sudo nginx -s reload').with_user('root') }
   end
 end


### PR DESCRIPTION
#48 

こちらの記事 https://blog.kksg.net/posts/letsencrypt-webroot を参考に。

現状、 current/public の中のパスを webroot として指定していたが、この方法だと current/public に root オーナーのディレクトリ・ファイルを作ってしまい、それがデプロイ完了時の releases のローテートの邪魔になってしまっていた。

これを回避するための PR。
