### PR TITLE
Datadog Agent のインストール

### DIFF
--- a/data_bags/credentials/datadog.json
+++ b/data_bags/credentials/datadog.json
@@ -1,0 +1,9 @@
+{
+  "id": "datadog",
+  "api_key": {
+    "encrypted_data": "iY8ZOAjv+5p71AKywv/FC/xaY34R7i39Vimm4nQKj1m/wSyPnZph/f+YT4jo\nDlrnNyVayuVunlIqbinQS6+lvg==\n",
+    "iv": "O3wNC0xmfNgCDp5EpM1Y8A==\n",
+    "version": 1,
+    "cipher": "aes-256-cbc"
+  }
+}

--- a/roles/prod.json
+++ b/roles/prod.json
@@ -5,6 +5,7 @@
 
   "run_list": [
     "recipe[crontab]",
+    "recipe[datadog]",
     "recipe[mackerel]",
     "recipe[mackerel::plugin]",
     "recipe[mkswap]"

--- a/site-cookbooks/datadog/metadata.rb
+++ b/site-cookbooks/datadog/metadata.rb
@@ -1,0 +1,7 @@
+name             'datadog'
+maintainer       'a-know'
+license          'All rights reserved'
+description      'Installs/Configures datadog agent'
+long_description 'ditto' # IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version          '0.1.0'
+depends          'yumrepo'

--- a/site-cookbooks/datadog/misc/install_agent_base.sh
+++ b/site-cookbooks/datadog/misc/install_agent_base.sh
@@ -1,0 +1,259 @@
+#!/bin/bash
+# (C) Datadog, Inc. 2010-2016
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+# Datadog Agent installation script: install and set up the Agent on supported Linux distributions
+# using the package manager and Datadog repositories.
+
+set -e
+logfile="ddagent-install.log"
+gist_request=/tmp/agent-gist-request.tmp
+gist_response=/tmp/agent-gist-response.tmp
+
+if [ $(command -v curl) ]; then
+    dl_cmd="curl -f"
+else
+    dl_cmd="wget --quiet"
+fi
+
+# Set up a named pipe for logging
+npipe=/tmp/$$.tmp
+mknod $npipe p
+
+# Log all output to a log for error checking
+tee <$npipe $logfile &
+exec 1>&-
+exec 1>$npipe 2>&1
+trap "rm -f $npipe" EXIT
+
+
+function on_error() {
+    printf "\033[31m$ERROR_MESSAGE
+It looks like you hit an issue when trying to install the Agent.
+
+Troubleshooting and basic usage information for the Agent are available at:
+
+    http://docs.datadoghq.com/guides/basic_agent_usage/
+
+If you're still having problems, please send an email to support@datadoghq.com
+with the contents of ddagent-install.log and we'll do our very best to help you
+solve your problem.\n\033[0m\n"
+}
+trap on_error ERR
+
+if [ -n "$DD_HOSTNAME" ]; then
+    dd_hostname=$DD_HOSTNAME
+fi
+
+if [ -n "$DD_API_KEY" ]; then
+    apikey=$DD_API_KEY
+fi
+
+if [ -n "$DD_INSTALL_ONLY" ]; then
+    no_start=true
+else
+    no_start=false
+fi
+
+if [ ! $apikey ]; then
+    printf "\033[31mAPI key not available in DD_API_KEY environment variable.\033[0m\n"
+    exit 1;
+fi
+
+# OS/Distro Detection
+# Try lsb_release, fallback with /etc/issue then uname command
+KNOWN_DISTRIBUTION="(Debian|Ubuntu|RedHat|CentOS|openSUSE|Amazon|Arista)"
+DISTRIBUTION=$(lsb_release -d 2>/dev/null | grep -Eo $KNOWN_DISTRIBUTION  || grep -Eo $KNOWN_DISTRIBUTION /etc/issue 2>/dev/null || grep -Eo $KNOWN_DISTRIBUTION /etc/Eos-release 2>/dev/null || uname -s)
+
+if [ $DISTRIBUTION = "Darwin" ]; then
+    printf "\033[31mThis script does not support installing on the Mac.
+
+Please use the 1-step script available at https://app.datadoghq.com/account/settings#agent/mac.\033[0m\n"
+    exit 1;
+
+elif [ -f /etc/debian_version -o "$DISTRIBUTION" == "Debian" -o "$DISTRIBUTION" == "Ubuntu" ]; then
+    OS="Debian"
+elif [ -f /etc/redhat-release -o "$DISTRIBUTION" == "RedHat" -o "$DISTRIBUTION" == "CentOS" -o "$DISTRIBUTION" == "openSUSE" -o "$DISTRIBUTION" == "Amazon" ]; then
+    OS="RedHat"
+# Some newer distros like Amazon may not have a redhat-release file
+elif [ -f /etc/system-release -o "$DISTRIBUTION" == "Amazon" ]; then
+    OS="RedHat"
+# Arista is based off of Fedora14/18 but do not have /etc/redhat-release
+elif [ -f /etc/Eos-release -o "$DISTRIBUTION" == "Arista" ]; then
+    OS="RedHat"
+fi
+
+# Root user detection
+if [ $(echo "$UID") = "0" ]; then
+    sudo_cmd=''
+else
+    sudo_cmd='sudo'
+fi
+
+DDBASE=false
+# Python Detection
+has_python=$(which python || echo "no")
+if [ "$has_python" != "no" ]; then
+    PY_VERSION=$(python -c 'import sys; print("{0}.{1}".format(sys.version_info[0], sys.version_info[1]))' 2>/dev/null || echo "TOO OLD")
+    if [ "$PY_VERSION" = "TOO OLD" ]; then
+        DDBASE=true
+    fi
+fi
+
+# Install the necessary package sources
+if [ $OS = "RedHat" ]; then
+    echo -e "\033[34m\n* Installing YUM sources for Datadog\n\033[0m"
+
+    UNAME_M=$(uname -m)
+    if [ "$UNAME_M"  == "i686" -o "$UNAME_M"  == "i386" -o "$UNAME_M"  == "x86" ]; then
+        ARCHI="i386"
+    else
+        ARCHI="x86_64"
+    fi
+
+    # Versions of yum on RedHat 5 and lower embed M2Crypto with SSL that doesn't support TLS1.2
+    if [ -f /etc/redhat-release ]; then
+        REDHAT_MAJOR_VERSION=$(grep -Eo "[0-9].[0-9]{1,2}" /etc/redhat-release | head -c 1)
+    fi
+    if [ -n "$REDHAT_MAJOR_VERSION" ] && [ "$REDHAT_MAJOR_VERSION" -le "5" ]; then
+        PROTOCOL="http"
+    else
+        PROTOCOL="https"
+    fi
+    $sudo_cmd sh -c "echo -e '[datadog]\nname = Datadog, Inc.\nbaseurl = $PROTOCOL://yum.datadoghq.com/rpm/$ARCHI/\nenabled=1\ngpgcheck=1\npriority=1\ngpgkey=$PROTOCOL://yum.datadoghq.com/DATADOG_RPM_KEY.public' > /etc/yum.repos.d/datadog.repo"
+
+    printf "\033[34m* Installing the Datadog Agent package\n\033[0m\n"
+
+    if $DDBASE; then
+        DD_BASE_INSTALLED=$(yum list installed datadog-agent-base > /dev/null 2>&1 || echo "no")
+        if [ "$DD_BASE_INSTALLED" != "no" ]; then
+            echo -e "\033[34m\n* Uninstall datadog-agent-base\n\033[0m"
+            $sudo_cmd yum -y remove datadog-agent-base
+        fi
+    fi
+    $sudo_cmd yum -y --disablerepo='*' --enablerepo='datadog' install datadog-agent
+elif [ $OS = "Debian" ]; then
+    printf "\033[34m\n* Installing apt-transport-https\n\033[0m\n"
+    $sudo_cmd apt-get update || printf "\033[31m'apt-get update' failed, the script will not install the latest version of apt-transport-https.\033[0m\n"
+    $sudo_cmd apt-get install -y apt-transport-https
+    printf "\033[34m\n* Installing APT package sources for Datadog\n\033[0m\n"
+    $sudo_cmd sh -c "echo 'deb https://apt.datadoghq.com/ stable main' > /etc/apt/sources.list.d/datadog.list"
+    $sudo_cmd apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 C7A7DA52
+
+    printf "\033[34m\n* Installing the Datadog Agent package\n\033[0m\n"
+    ERROR_MESSAGE="ERROR
+Failed to update the sources after adding the Datadog repository.
+This may be due to any of the configured APT sources failing -
+see the logs above to determine the cause.
+If the failing repository is Datadog, please contact Datadog support.
+*****
+"
+    $sudo_cmd apt-get update -o Dir::Etc::sourcelist="sources.list.d/datadog.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0"
+    ERROR_MESSAGE="ERROR
+Failed to install the Datadog package, sometimes it may be
+due to another APT source failing. See the logs above to
+determine the cause.
+If the cause is unclear, please contact Datadog support.
+*****
+"
+    $sudo_cmd apt-get install -y --force-yes datadog-agent
+    ERROR_MESSAGE=""
+else
+    printf "\033[31mYour OS or distribution are not supported by this install script.
+Please follow the instructions on the Agent setup page:
+
+    https://app.datadoghq.com/account/settings#agent\033[0m\n"
+    exit;
+fi
+
+# Set the configuration
+if [ -e /etc/dd-agent/datadog.conf ]; then
+    printf "\033[34m\n* Keeping old datadog.conf configuration file\n\033[0m\n"
+else
+    printf "\033[34m\n* Adding your API key to the Agent configuration: /etc/dd-agent/datadog.conf\n\033[0m\n"
+    $sudo_cmd sh -c "sed 's/api_key:.*/api_key: $apikey/' /etc/dd-agent/datadog.conf.example > /etc/dd-agent/datadog.conf"
+    if [ $dd_hostname ]; then
+        printf "\033[34m\n* Adding your HOSTNAME to the Agent configuration: /etc/dd-agent/datadog.conf\n\033[0m\n"
+        $sudo_cmd sh -c "sed -i 's/#hostname:.*/hostname: $dd_hostname/' /etc/dd-agent/datadog.conf"
+    fi
+    $sudo_cmd chown dd-agent:root /etc/dd-agent/datadog.conf
+    $sudo_cmd chmod 640 /etc/dd-agent/datadog.conf
+fi
+
+restart_cmd="$sudo_cmd /etc/init.d/datadog-agent restart"
+if command -v invoke-rc.d >/dev/null 2>&1; then
+    restart_cmd="$sudo_cmd invoke-rc.d datadog-agent restart"
+fi
+
+if $no_start; then
+    printf "\033[34m
+* DD_INSTALL_ONLY environment variable set: the newly installed version of the agent
+will not start by itself. You will have to do it manually using the following
+command:
+
+    $restart_cmd
+
+\033[0m\n"
+    exit
+fi
+
+printf "\033[34m* Starting the Agent...\n\033[0m\n"
+eval $restart_cmd
+
+# Wait for metrics to be submitted by the forwarder
+printf "\033[32m
+Your Agent has started up for the first time. We're currently verifying that
+data is being submitted. You should see your Agent show up in Datadog shortly
+at:
+
+    https://app.datadoghq.com/infrastructure\033[0m
+
+Waiting for metrics..."
+
+c=0
+while [ "$c" -lt "30" ]; do
+    sleep 1
+    echo -n "."
+    c=$(($c+1))
+done
+
+# Reuse the same counter
+c=0
+
+# The command to check the status of the forwarder might fail at first, this is expected
+# so we remove the trap and we set +e
+set +e
+trap - ERR
+
+$dl_cmd http://127.0.0.1:17123/status?threshold=0 > /dev/null 2>&1
+success=$?
+while [ "$success" -gt "0" ]; do
+    sleep 1
+    echo -n "."
+    $dl_cmd http://127.0.0.1:17123/status?threshold=0 > /dev/null 2>&1
+    success=$?
+    c=$(($c+1))
+
+    if [ "$c" -gt "15" -o "$success" -eq "0" ]; then
+        # After 15 tries, we give up, we restore the trap and set -e
+        # Also restore the trap on success
+        set -e
+        trap on_error ERR
+    fi
+done
+
+# Metrics are submitted, echo some instructions and exit
+printf "\033[32m
+
+Your Agent is running and functioning properly. It will continue to run in the
+background and submit metrics to Datadog.
+
+If you ever want to stop the Agent, run:
+
+    sudo /etc/init.d/datadog-agent stop
+
+And to run it again run:
+
+    sudo /etc/init.d/datadog-agent start
+
+\033[0m"

--- a/site-cookbooks/datadog/recipes/default.rb
+++ b/site-cookbooks/datadog/recipes/default.rb
@@ -1,0 +1,3 @@
+include_recipe 'yumrepo::datadog'
+
+package 'datadog-agent'

--- a/site-cookbooks/datadog/recipes/default.rb
+++ b/site-cookbooks/datadog/recipes/default.rb
@@ -1,3 +1,19 @@
 include_recipe 'yumrepo::datadog'
 
 package 'datadog-agent'
+
+datadog_credentials = Chef::EncryptedDataBagItem.load('credentials', 'datadog')
+
+
+template '/etc/dd-agent/datadog.conf' do
+  owner 'dd-agent'
+  group 'root'
+  mode '0640'
+  variables datadog_apikey: datadog_credentials['api_key'], datadog_hostname: 'home.a-know.me'
+  notifies :restart, 'service[datadog-agent]'
+end
+
+service 'datadog-agent' do
+  action [:enable, :start]
+  supports restart: true
+end

--- a/site-cookbooks/datadog/templates/datadog.conf.erb
+++ b/site-cookbooks/datadog/templates/datadog.conf.erb
@@ -1,0 +1,227 @@
+[Main]
+
+# The host of the Datadog intake server to send Agent data to
+dd_url: https://app.datadoghq.com
+
+# If you need a proxy to connect to the Internet, provide the settings here
+# proxy_host: my-proxy.com
+# proxy_port: 3128
+# proxy_user: user
+# proxy_password: password
+# To be used with some proxys that return a 302 which make curl switch from POST to GET
+# See http://stackoverflow.com/questions/8156073/curl-violate-rfc-2616-10-3-2-and-switch-from-post-to-get
+# proxy_forbid_method_switch: no
+
+# If you run the agent behind haproxy, you might want to set this to yes
+# skip_ssl_validation: no
+
+# The Datadog api key to associate your Agent's data with your organization.
+# Can be found here:
+# https://app.datadoghq.com/account/settings
+api_key: <%= @datadog_apikey %>
+
+# Force the hostname to whatever you want.
+hostname: <%= @datadog_hostname %>
+
+# Set the host's tags
+#tags: mytag, env:prod, role:database
+
+# Add one "dd_check:checkname" tag per running check. It makes it possible to slice
+# and dice per monitored app (= running Agent Check) on Datadog's backend.
+# create_dd_check_tags: no
+
+# Collect AWS EC2 custom tags as agent tags (requires an IAM role associated with the instance)
+# collect_ec2_tags: no
+
+# Incorporate security-groups into tags collected from AWS EC2
+# collect_security_groups: no
+
+# Enable Agent Developer Mode
+# Agent Developer Mode collects and sends more fine-grained metrics about agent and check performance
+# developer_mode: no
+# In developer mode, the number of runs to be included in a single collector profile
+# collector_profile_interval: 20
+
+# use unique hostname for GCE hosts, see http://dtdg.co/1eAynZk
+gce_updated_hostname: yes
+
+# Set the threshold for accepting points to allow anything
+# with recent_point_threshold seconds
+# Defaults to 30 seconds if no value is provided
+# recent_point_threshold: 30
+
+# Use mount points instead of volumes to track disk and fs metrics
+# DEPRECATED: use conf.d/disk.yaml instead to configure it
+use_mount: no
+
+# Change port the Agent is listening to
+# listen_port: 17123
+
+# Start a graphite listener on this port
+# graphite_listen_port: 17124
+
+# Additional directory to look for Datadog checks
+# additional_checksd: /etc/dd-agent/checks.d/
+
+# Allow non-local traffic to this Agent
+# This is required when using this Agent as a proxy for other Agents
+# that might not have an internet connection
+# For more information, please see
+# https://github.com/DataDog/dd-agent/wiki/Network-Traffic-and-Proxy-Configuration
+# non_local_traffic: no
+
+# Select the Tornado HTTP Client in the forwarder
+# Default to the simple http client
+# use_curl_http_client: False
+
+# The loopback address the Forwarder and Dogstatsd will bind.
+# Optional, it is mainly used when running the agent on Openshift
+# bind_host: localhost
+
+# If enabled the collector will capture a metric for check run times.
+# check_timings: no
+
+# If you want to remove the 'ww' flag from ps catching the arguments of processes
+# for instance for security reasons
+# exclude_process_args: no
+
+# histogram_aggregates: max, median, avg, count
+# histogram_percentiles: 0.95
+
+# ========================================================================== #
+# Service Discovery                                                          #
+# See https://github.com/DataDog/dd-agent/wiki/Service-Discovery for details #
+# ========================================================================== #
+#
+# Service discovery allows the agent to look for running services
+# and load a configuration object for the one it recognizes.
+# This feature is disabled by default.
+# Uncomment this line to enable it (works for docker containers only for now).
+# service_discovery_backend: docker
+#
+# Define which key/value store must be used to look for configuration templates.
+# Default is etcd. Consul is also supported.
+# sd_config_backend: etcd
+#
+# Settings for connecting to the service discovery backend.
+# sd_backend_host: 127.0.0.1
+# sd_backend_port: 4001
+#
+# By default, the agent will look for the configuration templates under the
+# `/datadog/check_configs` key in the back-end. If you wish otherwise, uncomment this option
+# and modify its value.
+# sd_template_dir: /datadog/check_configs
+
+# ========================================================================== #
+# DogStatsd configuration                                                    #
+# ========================================================================== #
+
+# If you don't want to enable the DogStatsd server, set this option to no
+# use_dogstatsd: yes
+
+# DogStatsd is a small server that aggregates your custom app metrics. For
+# usage information, check out http://docs.datadoghq.com/guides/dogstatsd/
+
+#  Make sure your client is sending to the same port.
+# dogstatsd_port : 8125
+
+# By default dogstatsd will post aggregate metrics to the Agent (which handles
+# errors/timeouts/retries/etc). To send directly to the datadog api, set this
+# to https://app.datadoghq.com.
+# dogstatsd_target : http://localhost:17123
+
+# If you want to forward every packet received by the dogstatsd server
+# to another statsd server, uncomment these lines.
+# WARNING: Make sure that forwarded packets are regular statsd packets and not "dogstatsd" packets,
+# as your other statsd server might not be able to handle them.
+# statsd_forward_host: address_of_own_statsd_server
+# statsd_forward_port: 8125
+
+# you may want all statsd metrics coming from this host to be namespaced
+# in some way; if so, configure your namespace here. a metric that looks
+# like `metric.name` will instead become `namespace.metric.name`
+# statsd_metric_namespace:
+
+# By default, dogstatsd supports only plain ASCII packets. However, most
+# (dog)statsd client support UTF8 by encoding packets before sending them
+# this option enables UTF8 decoding in case you need it.
+# However, it comes with a performance overhead of ~10% in the dogstatsd
+# server. This will be taken care of properly in the new gen agent core.
+# utf8_decoding: false
+
+# ========================================================================== #
+# Service-specific configuration                                             #
+# ========================================================================== #
+
+# -------------------------------------------------------------------------- #
+#   Ganglia                                                                  #
+# -------------------------------------------------------------------------- #
+
+# Ganglia host where gmetad is running
+#ganglia_host: localhost
+
+# Ganglia port where gmetad is running
+#ganglia_port: 8651
+
+# -------------------------------------------------------------------------- #
+#  Dogstream (log file parser)
+# -------------------------------------------------------------------------- #
+
+# Comma-separated list of logs to parse and optionally custom parsers to use.
+# The form should look like this:
+#
+#   dogstreams: /path/to/log1:parsers_module:custom_parser, /path/to/log2, /path/to/log3, ...
+#
+# Or this:
+#
+#   dogstreams: /path/to/log1:/path/to/my/parsers_module.py:custom_parser, /path/to/log2, /path/to/log3, ...
+#
+# Each entry is a path to a log file and optionally a Python module/function pair
+# separated by colons.
+#
+# Custom parsers should take a 2 parameters, a logger object and
+# a string parameter of the current line to parse. It should return a tuple of
+# the form:
+#   (metric (str), timestamp (unix timestamp), value (float), attributes (dict))
+# where attributes should at least contain the key 'metric_type', specifying
+# whether the given metric is a 'counter' or 'gauge'.
+#
+# Unless parsers are specified with an absolute path, the modules must exist in
+# the Agent's PYTHONPATH. You can set this as an environment variable when
+# starting the Agent. If the name of the custom parser function is not passed,
+# 'parser' is assumed.
+#
+# If this value isn't specified, the default parser assumes this log format:
+#     metric timestamp value key0=val0 key1=val1 ...
+#
+
+# ========================================================================== #
+# Custom Emitters                                                            #
+# ========================================================================== #
+
+# Comma-separated list of emitters to be used in addition to the standard one
+#
+# Expected to be passed as a comma-separated list of colon-delimited
+# name/object pairs.
+#
+# custom_emitters: /usr/local/my-code/emitters/rabbitmq.py:RabbitMQEmitter
+#
+# If the name of the emitter function is not specified, 'emitter' is assumed.
+
+
+# ========================================================================== #
+# Logging
+# ========================================================================== #
+
+# log_level: INFO
+
+# collector_log_file: /var/log/datadog/collector.log
+# forwarder_log_file: /var/log/datadog/forwarder.log
+# dogstatsd_log_file: /var/log/datadog/dogstatsd.log
+
+# if syslog is enabled but a host and port are not set, a local domain socket
+# connection will be attempted
+#
+# log_to_syslog: yes
+# syslog_host:
+# syslog_port:

--- a/site-cookbooks/yumrepo/files/default/datadog.repo
+++ b/site-cookbooks/yumrepo/files/default/datadog.repo
@@ -1,0 +1,7 @@
+[datadog]
+name = Datadog, Inc.
+baseurl = https://yum.datadoghq.com/rpm/x86_64/
+enabled=1
+gpgcheck=1
+priority=1
+gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public

--- a/site-cookbooks/yumrepo/recipes/datadog.rb
+++ b/site-cookbooks/yumrepo/recipes/datadog.rb
@@ -1,0 +1,3 @@
+cookbook_file '/etc/yum.repos.d/datadog.repo' do
+  action :create_if_missing
+end

--- a/spec/roles/web_prod_spec.rb
+++ b/spec/roles/web_prod_spec.rb
@@ -4,6 +4,7 @@ describe 'web' do
   it_behaves_like 'bigquery::settings'
   it_behaves_like 'chrony'
   it_behaves_like 'crontab'
+  it_behaves_like 'datadog'
   it_behaves_like 'firewalld::disable'
   it_behaves_like 'gcc'
   it_behaves_like 'git'

--- a/spec/shared/datadog.rb
+++ b/spec/shared/datadog.rb
@@ -2,4 +2,18 @@ shared_examples 'datadog' do
   describe package 'datadog-agent' do
     it { should be_installed }
   end
+
+  describe service 'datadog-agent' do
+    it { should be_enabled }
+    it { should be_running }
+  end
+
+  describe file '/etc/dd-agent/datadog.conf' do
+    it { should be_file }
+    it { should be_owned_by 'dd-agent' }
+    it { should be_grouped_into 'root' }
+    it { should be_mode 640 }
+    its(:content) { should match /^api_key:\s.{5,}$/ }
+    its(:content) { should match /^hostname: home.a-know.me/ }
+  end
 end

--- a/spec/shared/datadog.rb
+++ b/spec/shared/datadog.rb
@@ -1,0 +1,5 @@
+shared_examples 'datadog' do
+  describe package 'datadog-agent' do
+    it { should be_installed }
+  end
+end


### PR DESCRIPTION
この PR でやっていることは基本的に、公式で案内される `DD_API_KEY=xxx bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/dd-agent/master/packaging/datadog-agent/source/install_agent.sh)"` の chef レシピ化。