### PR TITLE
Something improve

### DIFF
--- a/mkr/monitors.json
+++ b/mkr/monitors.json
@@ -42,17 +42,6 @@
             "notificationInterval": 30
         },
         {
-            "id": "2BPpchfdef1",
-            "name": "リアルタイム訪問者数",
-            "type": "service",
-            "metric": "custom.blog-metricks-active-visitors.number",
-            "operator": ">",
-            "warning": 15,
-            "critical": 25,
-            "duration": 1,
-            "service": "a-know-home"
-        },
-        {
             "id": "2BCus5idQWm",
             "name": "[blog-metricks] bookmark-count",
             "type": "external",

--- a/site-cookbooks/crontab/recipes/default.rb
+++ b/site-cookbooks/crontab/recipes/default.rb
@@ -4,7 +4,7 @@ mackerel_credentials = Chef::EncryptedDataBagItem.load('credentials', 'mackerel'
 
 cron "Refresh Let's Encrypt cert-file (for a-know.me) and restart nginx" do
   user 'root'
-  command '/usr/local/bin/certbot/certbot-auto certonly --webroot -w /var/www/a-know-home/shared/public -d a-know.me --renew-by-default && sudo nginx -s reload'
+  command '/usr/local/bin/certbot/certbot-auto certonly --webroot -w /var/www/a-know-home/shared/public -d a-know.me --renew-by-default --non-interactive && sudo nginx -s reload'
   day '25'
   hour '4'
   minute '00'
@@ -12,7 +12,7 @@ end
 
 cron "Refresh Let's Encrypt cert-file (for home.a-know.me) and restart nginx" do
   user 'root'
-  command '/usr/local/bin/certbot/certbot-auto certonly --webroot -w /var/www/a-know-home/shared/public -d home.a-know.me --renew-by-default && sudo nginx -s reload'
+  command '/usr/local/bin/certbot/certbot-auto certonly --webroot -w /var/www/a-know-home/shared/public -d home.a-know.me --renew-by-default --non-interactive && sudo nginx -s reload'
   day '15'
   hour '4'
   minute '00'
@@ -20,7 +20,7 @@ end
 
 cron "Refresh Let's Encrypt cert-file (for grass-graph.shitemil.works) and restart nginx" do
   user 'root'
-  command '/usr/local/bin/certbot/certbot-auto certonly --webroot -w /var/www/a-know-home/shared/public -d grass-graph.shitemil.works --renew-by-default && sudo nginx -s reload'
+  command '/usr/local/bin/certbot/certbot-auto certonly --webroot -w /var/www/a-know-home/shared/public -d grass-graph.shitemil.works --renew-by-default --non-interactive && sudo nginx -s reload'
   day '10'
   hour '4'
   minute '00'

--- a/site-cookbooks/mackerel/files/mackerel-plugin-fluentd.conf
+++ b/site-cookbooks/mackerel/files/mackerel-plugin-fluentd.conf
@@ -1,0 +1,2 @@
+[plugin.metrics.fluentd]
+command = "/usr/local/bin/mackerel-plugin-fluentd"

--- a/site-cookbooks/mackerel/recipes/plugin.rb
+++ b/site-cookbooks/mackerel/recipes/plugin.rb
@@ -8,3 +8,17 @@ cookbook_file '/etc/mackerel-agent/conf.d/check-plugins.conf' do
   mode '0644'
   notifies :restart, 'service[mackerel-agent]'
 end
+
+cookbook_file '/etc/mackerel-agent/conf.d/check-plugins.conf' do
+  owner 'root'
+  group 'root'
+  mode '0644'
+  notifies :restart, 'service[mackerel-agent]'
+end
+
+cookbook_file '/etc/mackerel-agent/conf.d/mackerel-plugin-fluentd.conf' do
+  owner 'root'
+  group 'root'
+  mode '0644'
+  notifies :restart, 'service[mackerel-agent]'
+end

--- a/site-cookbooks/mackerel/templates/default/mackerel-agent.conf.erb
+++ b/site-cookbooks/mackerel/templates/default/mackerel-agent.conf.erb
@@ -13,6 +13,8 @@ apikey = "<%= @apikey %>"
 # Configuration for Custm Metrics Plugins
 # see also: http://help-ja.mackerel.io/entry/advanced/custom-metrics
 
+include = "/etc/mackerel-agent/conf.d/*.conf"
+
 # followings are mackerel-agent-plugins https://github.com/mackerelio/mackerel-agent-plugins
 
 # Plugin for Apache2 mod_status
@@ -120,5 +122,3 @@ type = "metric"
 
 [plugin.metrics.nginx_proc_sum]
 command = "echo -e \"proc_sum.nginx\t$(ps -f -u nginx | grep worker | grep -v grep | wc -l)\t$(date -u +%s)\""
-
-include = "/etc/mackerel-agent/conf.d/*.conf"

--- a/site-cookbooks/td-agent/templates/default/td-agent.conf.erb
+++ b/site-cookbooks/td-agent/templates/default/td-agent.conf.erb
@@ -1,4 +1,10 @@
 <source>
+  type monitor_agent
+  bind 0.0.0.0
+  port 24220
+</source>
+
+<source>
   type forward
 </source>
 

--- a/spec/shared/crontab.rb
+++ b/spec/shared/crontab.rb
@@ -1,7 +1,7 @@
 shared_examples 'crontab' do
   describe cron do
-    it { should have_entry('00 4 25 * * /usr/local/bin/certbot/certbot-auto certonly --webroot -w /var/www/a-know-home/shared/public -d a-know.me --renew-by-default && sudo nginx -s reload').with_user('root') }
-    it { should have_entry('00 4 15 * * /usr/local/bin/certbot/certbot-auto certonly --webroot -w /var/www/a-know-home/shared/public -d home.a-know.me --renew-by-default && sudo nginx -s reload').with_user('root') }
-    it { should have_entry('00 4 10 * * /usr/local/bin/certbot/certbot-auto certonly --webroot -w /var/www/a-know-home/shared/public -d grass-graph.shitemil.works --renew-by-default && sudo nginx -s reload').with_user('root') }
+    it { should have_entry('00 4 25 * * /usr/local/bin/certbot/certbot-auto certonly --webroot -w /var/www/a-know-home/shared/public -d a-know.me --renew-by-default --non-interactive && sudo nginx -s reload').with_user('root') }
+    it { should have_entry('00 4 15 * * /usr/local/bin/certbot/certbot-auto certonly --webroot -w /var/www/a-know-home/shared/public -d home.a-know.me --renew-by-default --non-interactive && sudo nginx -s reload').with_user('root') }
+    it { should have_entry('00 4 10 * * /usr/local/bin/certbot/certbot-auto certonly --webroot -w /var/www/a-know-home/shared/public -d grass-graph.shitemil.works --renew-by-default --non-interactive && sudo nginx -s reload').with_user('root') }
   end
 end

--- a/spec/shared/mackerel.rb
+++ b/spec/shared/mackerel.rb
@@ -30,5 +30,12 @@ shared_examples 'mackerel' do
       it { should be_grouped_into 'root' }
       it { should be_mode 644 }
     end
+
+    describe file '/etc/mackerel-agent/conf.d/mackerel-plugin-fluentd.conf' do
+      it { should be_file }
+      it { should be_owned_by 'root' }
+      it { should be_grouped_into 'root' }
+      it { should be_mode 644 }
+    end
   end
 end


### PR DESCRIPTION
* use monitor_agent of fluentd
    * and post fluentd metrics to mackerel
* Add `--non-interactive` foe certbot-auto