### PR TITLE
インフラ基盤のAWS への移行

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,19 +3,19 @@ require 'rspec/core/rake_task'
 
 hosts = [
   {
-    name:       'vm-web',
+    name:       [ 'vm-web' ],
     short_name: 'vm:web',
     role:       'web_base',
   },
   {
-    name:       'ci-web',
+    name:       [ 'ci-web' ],
     short_name: 'ci:web',
     role:       'web_base',
   },
   {
-    name:       'home.a-know.me',
-    short_name: 'prod:web',
-    role:       'web_prod',
+    name:       [ 'blue01', 'green01' ],
+    short_name: 'prod:aws',
+    role:       'aws_prod',
   },
 ]
 
@@ -32,10 +32,12 @@ namespace :spec do
   desc "Run serverspec to all hosts"
   task :all => hosts.map {|h| 'spec:' + h[:short_name] }
   hosts.each do |host|
-    desc "Run serverspec to #{host[:name]}"
-    ServerspecTask.new(host[:short_name].to_sym) do |t|
-      t.target = host[:name]
-      t.pattern = "spec/roles/#{host[:role]}_spec.rb"
+    host[:name].each do |hostname|
+      desc "Run serverspec to #{hostname}"
+      ServerspecTask.new(host[:short_name].to_sym) do |t|
+        t.target = hostname
+        t.pattern = "spec/roles/#{host[:role]}_spec.rb"
+      end
     end
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,7 @@ hosts = [
   {
     name:       [ 'ci-web' ],
     short_name: 'ci:web',
-    role:       'web_base',
+    role:       'aws_ci',
   },
   {
     name:       [ 'blue01', 'green01' ],

--- a/cloudformation.json
+++ b/cloudformation.json
@@ -186,7 +186,7 @@
           "Target": "HTTP:80/",
           "HealthyThreshold": "3",
           "UnhealthyThreshold": "5",
-          "Interval": "30",
+          "Interval": "300",
           "Timeout": "5"
         },
         "AccessLoggingPolicy": {

--- a/cloudformation.json
+++ b/cloudformation.json
@@ -164,14 +164,45 @@
         ]
       }
     },
+    "GreenPublicEC2Instance": {
+      "Type" : "AWS::EC2::Instance",
+      "Properties" : {
+        "ImageId" : "ami-eec1c380",
+        "InstanceType" : "t2.micro",
+        "KeyName" : "for-new-aws",
+        "Tags" : [
+          { "Key" : "Name", "Value" : "Web（緑）" }
+        ],
+        "NetworkInterfaces": [
+          {
+            "AssociatePublicIpAddress": "true",
+            "DeviceIndex": "0",
+            "DeleteOnTermination" : "true",
+            "PrivateIpAddress" : "10.0.2.10",
+            "SubnetId": { "Ref" : "GreenPublicSubnet" },
+            "GroupSet": [ { "Ref" : "SecurityGroupForPublic" } ]
+          }
+        ],
+        "BlockDeviceMappings" : [
+          {
+            "DeviceName" : "/dev/xvda",
+            "Ebs" : {
+               "VolumeType" : "standard",
+               "DeleteOnTermination" : "true",
+               "VolumeSize" : "30"
+            }
+          }
+        ]
+      }
+    },
     "ElasticLoadBalancer": {
       "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
       "Properties": {
         "Scheme": "internet-facing",
         "SecurityGroups": [ { "Ref" : "SecurityGroupForPublic" } ],
         "LoadBalancerName" : "ElasticLoadBalancer",
-        "Subnets" : [ { "Ref" : "BluePublicSubnet" } ],
-        "Instances" : [ { "Ref" : "BluePublicEC2Instance" } ],
+        "Subnets" : [ { "Ref" : "BluePublicSubnet" }, { "Ref" : "GreenPublicSubnet" } ],
+        "Instances" : [ { "Ref" : "BluePublicEC2Instance" }, { "Ref" : "GreenPublicEC2Instance" } ],
         "Tags" : [
           { "Key" : "Name", "Value" : "ELB" }
         ],

--- a/cloudformation.json
+++ b/cloudformation.json
@@ -1,0 +1,225 @@
+{
+  "AWSTemplateFormatVersion" : "2010-09-09",
+  "Mappings": {
+    "ELBLogger": {
+      "us-east-1":      { "AccountID": "127311923021" },
+      "us-west-2":      { "AccountID": "797873946194" },
+      "us-west-1":      { "AccountID": "027434742980" },
+      "eu-west-1":      { "AccountID": "156460612806" },
+      "ap-southeast-1": { "AccountID": "114774131450" },
+      "ap-southeast-2": { "AccountID": "783225319266" },
+      "ap-northeast-1": { "AccountID": "582318560864" },
+      "sa-east-1":      { "AccountID": "507241528517" },
+      "us-gov-west-1":  { "AccountID": "048591011584" }
+    }
+  },
+  "Resources" : {
+    "MainVPC" : {
+      "Type" : "AWS::EC2::VPC",
+      "Properties" : {
+        "CidrBlock" : "10.0.0.0/16",
+        "EnableDnsSupport" : "true",
+        "EnableDnsHostnames" : "true",
+        "InstanceTenancy" : "default",
+        "Tags" : [ {"Key" : "Name", "Value" : "メインVPC領域"} ]
+      }
+    },
+    "BluePublicSubnet" : {
+      "Type" : "AWS::EC2::Subnet",
+      "Properties" : {
+        "VpcId" : { "Ref" : "MainVPC" },
+        "CidrBlock" : "10.0.1.0/24",
+        "AvailabilityZone" : "ap-northeast-1a",
+        "Tags" : [ { "Key" : "Name", "Value" : "パブリックサブネット（青）" } ]
+      }
+    },
+    "GreenPublicSubnet" : {
+      "Type" : "AWS::EC2::Subnet",
+      "Properties" : {
+        "VpcId" : { "Ref" : "MainVPC" },
+        "CidrBlock" : "10.0.2.0/24",
+        "AvailabilityZone" : "ap-northeast-1c",
+        "Tags" : [ { "Key" : "Name", "Value" : "パブリックサブネット（緑）" } ]
+      }
+    },
+    "MainIGW" : {
+      "Type" : "AWS::EC2::InternetGateway",
+      "Properties" : {
+        "Tags" : [ {"Key" : "Name", "Value" : "メインインターネットゲートウェイ"}]
+      }
+    },
+    "AttachMainIGW" : {
+      "Type" : "AWS::EC2::VPCGatewayAttachment",
+      "Properties" : {
+        "VpcId" : { "Ref" : "MainVPC" },
+        "InternetGatewayId" : { "Ref" : "MainIGW" }
+      }
+    },
+    "BluePublicRouteTable" : {
+      "Type" : "AWS::EC2::RouteTable",
+      "Properties" : {
+        "VpcId" : { "Ref" : "MainVPC" },
+        "Tags" : [ { "Key" : "Name", "Value" : "パブリックルートテーブル（青）" } ]
+      }
+    },
+    "GreenPublicRouteTable" : {
+      "Type" : "AWS::EC2::RouteTable",
+      "Properties" : {
+        "VpcId" : { "Ref" : "MainVPC" },
+        "Tags" : [ { "Key" : "Name", "Value" : "パブリックルートテーブル（緑）" } ]
+      }
+    },
+    "AttachBluePublicRouteTableToBluePublicSubnet" : {
+      "Type" : "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties" : {
+        "RouteTableId" : { "Ref" : "BluePublicRouteTable" },
+        "SubnetId" : { "Ref" : "BluePublicSubnet" }
+      }
+    },
+    "AttachGreenPublicRouteTableToGreenPublicSubnet" : {
+      "Type" : "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties" : {
+        "RouteTableId" : { "Ref" : "GreenPublicRouteTable" },
+        "SubnetId" : { "Ref" : "GreenPublicSubnet" }
+      }
+    },
+    "BluePublicRoute" : {
+      "Type" : "AWS::EC2::Route",
+      "Properties" : {
+        "RouteTableId" : { "Ref" : "BluePublicRouteTable" },
+        "DestinationCidrBlock" : "0.0.0.0/0",
+        "GatewayId" : { "Ref" : "MainIGW" }
+      }
+    },
+    "GreenPublicRoute" : {
+      "Type" : "AWS::EC2::Route",
+      "Properties" : {
+        "RouteTableId" : { "Ref" : "GreenPublicRouteTable" },
+        "DestinationCidrBlock" : "0.0.0.0/0",
+        "GatewayId" : { "Ref" : "MainIGW" }
+      }
+    },
+    "SecurityGroupForPublic": {
+      "Type" : "AWS::EC2::SecurityGroup",
+      "Properties" : {
+        "GroupDescription" : "SecurityGroup for web-server instance in public-subnet",
+        "SecurityGroupIngress" : [
+          {
+             "IpProtocol" : "tcp",
+             "FromPort" : "22",
+             "ToPort" : "22",
+             "CidrIp" : "0.0.0.0/0"
+          },
+          {
+            "IpProtocol" : "tcp",
+            "FromPort" : "80",
+            "ToPort" : "80",
+            "CidrIp" : "0.0.0.0/0"
+          },
+          {
+            "IpProtocol" : "tcp",
+            "FromPort" : "443",
+            "ToPort" : "443",
+            "CidrIp" : "0.0.0.0/0"
+          },
+          {
+            "IpProtocol" : "icmp",
+            "FromPort" : "-1",
+            "ToPort" : "-1",
+            "CidrIp" : "0.0.0.0/0"
+          }
+        ],
+        "Tags" :  [ { "Key" : "Name", "Value" : "WEB-SG" } ],
+        "VpcId" : { "Ref" : "MainVPC" }
+      }
+    },
+    "BluePublicEC2Instance": {
+      "Type" : "AWS::EC2::Instance",
+      "Properties" : {
+        "ImageId" : "ami-eec1c380",
+        "InstanceType" : "t2.micro",
+        "KeyName" : "for-new-aws",
+        "Tags" : [
+          { "Key" : "Name", "Value" : "Web（青）" }
+        ],
+        "NetworkInterfaces": [
+          {
+            "AssociatePublicIpAddress": "true",
+            "DeviceIndex": "0",
+            "DeleteOnTermination" : "true",
+            "PrivateIpAddress" : "10.0.1.10",
+            "SubnetId": { "Ref" : "BluePublicSubnet" },
+            "GroupSet": [ { "Ref" : "SecurityGroupForPublic" } ]
+          }
+        ],
+        "BlockDeviceMappings" : [
+          {
+            "DeviceName" : "/dev/xvda",
+            "Ebs" : {
+               "VolumeType" : "standard",
+               "DeleteOnTermination" : "true",
+               "VolumeSize" : "30"
+            }
+          }
+        ]
+      }
+    },
+    "ElasticLoadBalancer": {
+      "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
+      "Properties": {
+        "Scheme": "internet-facing",
+        "SecurityGroups": [ { "Ref" : "SecurityGroupForPublic" } ],
+        "LoadBalancerName" : "ElasticLoadBalancer",
+        "Subnets" : [ { "Ref" : "BluePublicSubnet" } ],
+        "Instances" : [ { "Ref" : "BluePublicEC2Instance" } ],
+        "Tags" : [
+          { "Key" : "Name", "Value" : "ELB" }
+        ],
+        "Listeners": [
+          {
+            "LoadBalancerPort": "80",
+            "InstancePort": "80",
+            "Protocol": "HTTP"
+          }
+        ],
+        "HealthCheck": {
+          "Target": "HTTP:80/",
+          "HealthyThreshold": "3",
+          "UnhealthyThreshold": "5",
+          "Interval": "30",
+          "Timeout": "5"
+        },
+        "AccessLoggingPolicy": {
+          "Enabled" : "true",
+          "S3BucketName" : { "Ref":"ELBLogBucket" }
+        }
+      }
+    },
+    "ELBLogBucket" : {
+      "Type" : "AWS::S3::Bucket",
+      "DeletionPolicy" : "Retain"
+    },
+    "ELBLogBucketPolicy" : {
+      "Type" : "AWS::S3::BucketPolicy",
+      "Properties" : {
+        "Bucket" : { "Ref" : "ELBLogBucket" },
+        "PolicyDocument" : {
+          "Id" : "ELBLogBucketPolicy",
+          "Statement" : [
+            {
+              "Sid" : "WriteAccess",
+              "Action" : [ "s3:PutObject" ],
+              "Effect" : "Allow",
+              "Resource" : {
+                "Fn::Join" : [ "", [ "arn:aws:s3:::", { "Ref" : "ELBLogBucket" } , "/AWSLogs/", { "Ref" : "AWS::AccountId" }, "/*" ] ]
+              },
+              "Principal" : {
+                "AWS" : { "Fn::FindInMap" : [ "ELBLogger", { "Ref": "AWS::Region" }, "AccountID" ] }
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/nodes/blue01.json
+++ b/nodes/blue01.json
@@ -1,0 +1,14 @@
+{
+  "hostname_attr": {
+    "hostname": "centrage-blue01"
+  },
+  "instance_kind": {
+    "color": "blue"
+  },
+  "run_list": [
+    "role[aws-base]",
+    "role[aws-middleware]",
+    "role[aws-application]",
+    "role[aws-prod]"
+  ]
+}

--- a/nodes/ci-web.json
+++ b/nodes/ci-web.json
@@ -1,9 +1,13 @@
 {
   "hostname_attr": {
-    "hostname": "ci-centrage"
+    "hostname": "ci-centrage-blue99"
+  },
+  "instance_kind": {
+    "color": "blue"
   },
   "run_list": [
-    "role[base]",
-    "role[vm]"
+    "role[aws-base]",
+    "role[aws-middleware]",
+    "role[aws-application]"
   ]
 }

--- a/nodes/green01.json
+++ b/nodes/green01.json
@@ -1,0 +1,14 @@
+{
+  "hostname_attr": {
+    "hostname": "centrage-green01"
+  },
+  "instance_kind": {
+    "color": "green"
+  },
+  "run_list": [
+    "role[aws-base]",
+    "role[aws-middleware]",
+    "role[aws-application]",
+    "role[aws-prod]"
+  ]
+}

--- a/roles/aws-application.json
+++ b/roles/aws-application.json
@@ -1,0 +1,11 @@
+{
+  "name": "base-app",
+  "description": "base application role",
+  "json_class": "Chef::Role",
+
+  "run_list": [
+    "recipe[bigquery::settings]",
+    "recipe[nginx::aws]",
+    "recipe[td-agent::aws_setting]"
+  ]
+}

--- a/roles/aws-base.json
+++ b/roles/aws-base.json
@@ -1,0 +1,10 @@
+{
+  "name": "aws-base",
+  "description": "aws base role",
+  "json_class": "Chef::Role",
+
+  "run_list": [
+    "recipe[sudoers]",
+    "recipe[users]"
+  ]
+}

--- a/roles/aws-middleware.json
+++ b/roles/aws-middleware.json
@@ -17,16 +17,16 @@
     "recipe[git]",
     "recipe[hostname]",
     "recipe[imagemagick]",
-    "recipe[sysstat]",
     "recipe[logrotate]",
     "recipe[mkr]",
     "recipe[net-tools]",
+    "recipe[openssh]",
     "recipe[openssl]",
     "recipe[openssl-devel]",
-    "recipe[openssh]",
     "recipe[patch]",
     "recipe[ruby]",
     "recipe[selinux::permissive]",
+    "recipe[sysstat]",
     "recipe[timezone]",
     "recipe[zlib::devel]"
   ]

--- a/roles/aws-middleware.json
+++ b/roles/aws-middleware.json
@@ -18,7 +18,6 @@
     "recipe[hostname]",
     "recipe[imagemagick]",
     "recipe[sysstat]",
-    "recipe[letsencrypt]",
     "recipe[logrotate]",
     "recipe[mkr]",
     "recipe[net-tools]",

--- a/roles/aws-middleware.json
+++ b/roles/aws-middleware.json
@@ -1,0 +1,34 @@
+{
+  "name": "base-software",
+  "description": "base software role",
+  "json_class": "Chef::Role",
+
+  "override_attributes": {
+    "ruby": {
+      "version": "2.3.1",
+      "checksum": "15c4e69fa84e93555e324c1a624f66f56ac3a244427ad26e14e60e052fc7d4a6"
+    }
+  },
+
+  "run_list": [
+    "recipe[chrony]",
+    "recipe[firewalld::disable]",
+    "recipe[gcc]",
+    "recipe[git]",
+    "recipe[hostname]",
+    "recipe[imagemagick]",
+    "recipe[sysstat]",
+    "recipe[letsencrypt]",
+    "recipe[logrotate]",
+    "recipe[mkr]",
+    "recipe[net-tools]",
+    "recipe[openssl]",
+    "recipe[openssl-devel]",
+    "recipe[openssh]",
+    "recipe[patch]",
+    "recipe[ruby]",
+    "recipe[selinux::permissive]",
+    "recipe[timezone]",
+    "recipe[zlib::devel]"
+  ]
+}

--- a/roles/aws-prod.json
+++ b/roles/aws-prod.json
@@ -1,0 +1,12 @@
+{
+  "name": "aws-prod",
+  "description": "aws prod role",
+  "json_class": "Chef::Role",
+
+  "run_list": [
+    "recipe[crontab]",
+    "recipe[mackerel]",
+    "recipe[mackerel::plugin]",
+    "recipe[mkswap]"
+  ]
+}

--- a/site-cookbooks/bigquery/files/default/active_visitors_count_schema.json
+++ b/site-cookbooks/bigquery/files/default/active_visitors_count_schema.json
@@ -1,4 +1,5 @@
 [
   { "name": "time",    "type": "timestamp" },
-  { "name": "number",  "type": "integer"  }
+  { "name": "number",  "type": "integer"  },
+  { "name": "id",  "type": "string"  }
 ]

--- a/site-cookbooks/bigquery/files/default/bookmark_count_schema.json
+++ b/site-cookbooks/bigquery/files/default/bookmark_count_schema.json
@@ -1,4 +1,5 @@
 [
   { "name": "time",    "type": "timestamp" },
-  { "name": "count",  "type": "integer"  }
+  { "name": "count",  "type": "integer"  },
+  { "name": "id",  "type": "string"  }
 ]

--- a/site-cookbooks/bigquery/files/default/hatena_star_count_schema.json
+++ b/site-cookbooks/bigquery/files/default/hatena_star_count_schema.json
@@ -1,5 +1,6 @@
 [
   { "name": "time",    "type": "timestamp" },
   { "name": "blog_star_count", "type": "integer"  },
-  { "name": "photo_star_count", "type": "integer"  }
+  { "name": "photo_star_count", "type": "integer"  },
+  { "name": "id", "type": "string"  }
 ]

--- a/site-cookbooks/bigquery/files/default/nginx_access_log_schema.json
+++ b/site-cookbooks/bigquery/files/default/nginx_access_log_schema.json
@@ -13,5 +13,7 @@
   { "name": "runtime",   "type": "float" },
   { "name": "vhost", "type": "string" },
   { "name": "method",    "type": "string" },
-  { "name": "uri",    "type": "string"  }
+  { "name": "uri",    "type": "string"  },
+  { "name": "hostname",    "type": "string"  },
+  { "name": "id",    "type": "string"  }
 ]

--- a/site-cookbooks/bigquery/files/default/rails_production_log_schema.json
+++ b/site-cookbooks/bigquery/files/default/rails_production_log_schema.json
@@ -1,5 +1,7 @@
 [
   { "name": "time",    "type": "timestamp" },
   { "name": "level",  "type": "string"  },
-  { "name": "message",  "type": "string"  }
+  { "name": "message",  "type": "string"  },
+  { "name": "hostname",    "type": "string"  },
+  { "name": "id",    "type": "string"  }
 ]

--- a/site-cookbooks/bigquery/files/default/subscribers_count_schema.json
+++ b/site-cookbooks/bigquery/files/default/subscribers_count_schema.json
@@ -7,5 +7,6 @@
   { "name": "feedly_hateda", "type": "integer"  },
   { "name": "feedly_hateblo_feed", "type": "integer"  },
   { "name": "feedly_hateblo_rss", "type": "integer"  },
-  { "name": "hateblo_subscribers", "type": "integer"  }
+  { "name": "hateblo_subscribers", "type": "integer"  },
+  { "name": "id", "type": "string"  }
 ]

--- a/site-cookbooks/bigquery/recipes/settings.rb
+++ b/site-cookbooks/bigquery/recipes/settings.rb
@@ -55,10 +55,3 @@ cookbook_file '/etc/td-agent/settings/active_visitors_count_schema.json' do
   mode     0644
   source   'active_visitors_count_schema.json'
 end
-
-cookbook_file '/etc/td-agent/settings/steps_schema.json' do
-  user     'root'
-  group    'root'
-  mode     0644
-  source   'steps_schema.json'
-end

--- a/site-cookbooks/crontab/recipes/default.rb
+++ b/site-cookbooks/crontab/recipes/default.rb
@@ -2,14 +2,6 @@ include_recipe 'crond'
 data_bag = Chef::EncryptedDataBagItem.load('webhook_urls', 'knock')
 mackerel_credentials = Chef::EncryptedDataBagItem.load('credentials', 'mackerel')
 
-cron "Refresh Let's Encrypt cert-file (for grass-graph.shitemil.works and a-know.shitemil.works)" do
-  user 'root'
-  command '/usr/local/bin/certbot/certbot-auto certonly --webroot -w /var/www/a-know-home/shared/public -d grass-graph.shitemil.works -d a-know.shitemil.works --renew-by-default --non-interactive'
-  day '10'
-  hour '4'
-  minute '00'
-end
-
 cron "Post service metric for grass--graph generated image count" do
   user 'root'
   echo_cmd = 'echo -e "grass-graph.images.count\t$(ls -1 /var/www/a-know-home/shared/tmp/gg_others_svg/${d} | wc -l)\t$(date -u +\\%s)"'

--- a/site-cookbooks/crontab/recipes/default.rb
+++ b/site-cookbooks/crontab/recipes/default.rb
@@ -2,25 +2,9 @@ include_recipe 'crond'
 data_bag = Chef::EncryptedDataBagItem.load('webhook_urls', 'knock')
 mackerel_credentials = Chef::EncryptedDataBagItem.load('credentials', 'mackerel')
 
-cron "Refresh Let's Encrypt cert-file (for a-know.me) and restart nginx" do
+cron "Refresh Let's Encrypt cert-file (for grass-graph.shitemil.works and a-know.shitemil.works)" do
   user 'root'
-  command '/usr/local/bin/certbot/certbot-auto certonly --webroot -w /var/www/a-know-home/shared/public -d a-know.me --renew-by-default --non-interactive && sudo nginx -s reload'
-  day '25'
-  hour '4'
-  minute '00'
-end
-
-cron "Refresh Let's Encrypt cert-file (for home.a-know.me) and restart nginx" do
-  user 'root'
-  command '/usr/local/bin/certbot/certbot-auto certonly --webroot -w /var/www/a-know-home/shared/public -d home.a-know.me --renew-by-default --non-interactive && sudo nginx -s reload'
-  day '15'
-  hour '4'
-  minute '00'
-end
-
-cron "Refresh Let's Encrypt cert-file (for grass-graph.shitemil.works) and restart nginx" do
-  user 'root'
-  command '/usr/local/bin/certbot/certbot-auto certonly --webroot -w /var/www/a-know-home/shared/public -d grass-graph.shitemil.works --renew-by-default --non-interactive && sudo nginx -s reload'
+  command '/usr/local/bin/certbot/certbot-auto certonly --webroot -w /var/www/a-know-home/shared/public -d grass-graph.shitemil.works -d a-know.shitemil.works --renew-by-default --non-interactive'
   day '10'
   hour '4'
   minute '00'

--- a/site-cookbooks/logrotate/recipes/default.rb
+++ b/site-cookbooks/logrotate/recipes/default.rb
@@ -1,1 +1,3 @@
+package 'logrotate'
+
 template '/etc/logrotate.d/app'

--- a/site-cookbooks/mackerel/templates/default/mackerel-agent.conf.erb
+++ b/site-cookbooks/mackerel/templates/default/mackerel-agent.conf.erb
@@ -3,7 +3,7 @@
 # verbose = false
 apikey = "<%= @apikey %>"
 
-roles = [ "home_a-know_me:aws-web" ]
+roles = [ "grass-graph:webapp" ]
 
 diagnostic = true
 

--- a/site-cookbooks/mackerel/templates/default/mackerel-agent.conf.erb
+++ b/site-cookbooks/mackerel/templates/default/mackerel-agent.conf.erb
@@ -3,6 +3,8 @@
 # verbose = false
 apikey = "<%= @apikey %>"
 
+roles = [ "home_a-know_me:aws-web" ]
+
 diagnostic = true
 
 # Configuration for connection

--- a/site-cookbooks/nginx/files/default/nginx.conf
+++ b/site-cookbooks/nginx/files/default/nginx.conf
@@ -27,7 +27,8 @@ http {
                       "\truntime:$upstream_http_x_runtime"
                       "\tvhost:$host"
                       "\tmethod:$request_method"
-                      "\turi:$request_uri";
+                      "\turi:$request_uri"
+                      "\thostname:$hostname";
 
     access_log  /var/log/nginx/access.log  ltsv;
 

--- a/site-cookbooks/nginx/recipes/aws.rb
+++ b/site-cookbooks/nginx/recipes/aws.rb
@@ -1,0 +1,39 @@
+include_recipe 'yumrepo::nginx'
+
+package 'nginx'
+
+service 'nginx' do
+  action [:enable, :start]
+  supports reload: true
+end
+
+%w(default.conf example_ssl.conf).each do |file|
+  file "/etc/nginx/conf.d/#{file}" do
+    action :delete
+    notifies :reload, 'service[nginx]'
+  end
+end
+
+cookbook_file '/etc/nginx/nginx.conf' do
+  user     'root'
+  group    'root'
+  mode     0644
+  source   'nginx.conf'
+  notifies :reload, 'service[nginx]'
+end
+
+template '/etc/nginx/conf.d/a-know.shitemil.works.conf' do
+  user     'root'
+  group    'root'
+  mode     0644
+  notifies :reload, 'service[nginx]'
+end
+
+template '/etc/nginx/conf.d/grass-graph.shitemil.works.conf' do
+  user     'root'
+  group    'root'
+  mode     0644
+  notifies :reload, 'service[nginx]'
+end
+
+include_recipe 'nginx::logrotate'

--- a/site-cookbooks/nginx/templates/default/a-know.me.conf.erb
+++ b/site-cookbooks/nginx/templates/default/a-know.me.conf.erb
@@ -5,29 +5,6 @@ upstream naked_unicorn {
 server {
     listen       80;
     server_name  a-know.me;
-    return 301 https://$host$request_uri;
-}
-
-server {
-    listen       443 ssl;
-    server_name  a-know.me;
-
-    ssl_certificate /etc/letsencrypt/live/a-know.me/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/a-know.me/privkey.pem;
-
-    ssl_session_cache   shared:SSL:3m;
-    ssl_buffer_size     4k;
-    ssl_session_timeout 10m;
-
-    ssl_prefer_server_ciphers on;
-    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-    ssl_ciphers 'ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS';
-
-    # OCSP stapling
-    ssl_stapling on;
-    ssl_stapling_verify on;
-    ssl_trusted_certificate /etc/letsencrypt/live/a-know.me/fullchain.pem;
-    resolver 8.8.8.8 8.8.4.4 valid=300s;
 
     root /var/www/a-know-home/current/public;
 

--- a/site-cookbooks/nginx/templates/default/a-know.shitemil.works.conf.erb
+++ b/site-cookbooks/nginx/templates/default/a-know.shitemil.works.conf.erb
@@ -6,6 +6,9 @@ server {
     listen       80;
     server_name  a-know.shitemil.works;
 
+    set_real_ip_from 10.0.0.0/8; # ELBのIPが複数あるのでまとめて指定
+    real_ip_header  X-Forwarded-For;
+
     root /var/www/a-know-home/current/public;
 
     access_log /var/log/nginx/a-know.shitemil.works.access.log ltsv;

--- a/site-cookbooks/nginx/templates/default/a-know.shitemil.works.conf.erb
+++ b/site-cookbooks/nginx/templates/default/a-know.shitemil.works.conf.erb
@@ -34,11 +34,11 @@ server {
     }
 
     location ~* .*\.(json|js|html|less|css|eot|svg|ttf|woff|otf|scss|txt|jpg|png|gif|map|ico) {
-      root /var/www/a-know-home/current/public;
+      rewrite ^(.*)$ https://home.a-know.me/ redirect;
     }
 
     location / {
-      try_files $uri $uri/index.html $uri.html @unicorn;
+      rewrite ^(.*)$ https://home.a-know.me/ redirect;
     }
 
     location @unicorn {

--- a/site-cookbooks/nginx/templates/default/a-know.shitemil.works.conf.erb
+++ b/site-cookbooks/nginx/templates/default/a-know.shitemil.works.conf.erb
@@ -1,0 +1,52 @@
+upstream unicorn {
+  server unix:/var/www/a-know-home/current/tmp/sockets/unicorn.socket;
+}
+
+server {
+    listen       80;
+    server_name  a-know.shitemil.works;
+
+    root /var/www/a-know-home/current/public;
+
+    access_log /var/log/nginx/a-know.shitemil.works.access.log ltsv;
+    error_log  /var/log/nginx/a-know.shitemil.works.error.log;
+
+    location /.well-known {
+      default_type "text/plain";
+      root /var/www/a-know-home/shared/public;
+    }
+
+    location ~ /(webdav|muieblackcat|manager/html|cgi-bin) {
+      deny all;
+    }
+
+    location ~ .*\.php {
+      deny all;
+    }
+
+    location ~ /(blog_metricks|a_know_metricks)/.+ {
+      allow 59.106.108.64/26;
+      deny all;
+      try_files $uri $uri/index.html $uri.html @unicorn;
+    }
+
+    location ~* .*\.(json|js|html|less|css|eot|svg|ttf|woff|otf|scss|txt|jpg|png|gif|map|ico) {
+      root /var/www/a-know-home/current/public;
+    }
+
+    location / {
+      try_files $uri $uri/index.html $uri.html @unicorn;
+    }
+
+    location @unicorn {
+      satisfy any;
+      allow   all;
+      proxy_pass http://unicorn;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-Host $host;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header Host $http_host;
+      proxy_redirect off;
+    }
+}

--- a/site-cookbooks/nginx/templates/default/a-know.shitemil.works.conf.erb
+++ b/site-cookbooks/nginx/templates/default/a-know.shitemil.works.conf.erb
@@ -14,11 +14,6 @@ server {
     access_log /var/log/nginx/a-know.shitemil.works.access.log ltsv;
     error_log  /var/log/nginx/a-know.shitemil.works.error.log;
 
-    location /.well-known {
-      default_type "text/plain";
-      root /var/www/a-know-home/shared/public;
-    }
-
     location ~ /(webdav|muieblackcat|manager/html|cgi-bin) {
       deny all;
     }

--- a/site-cookbooks/nginx/templates/default/grass-graph.shitemil.works.conf.erb
+++ b/site-cookbooks/nginx/templates/default/grass-graph.shitemil.works.conf.erb
@@ -13,11 +13,6 @@ server {
 
     add_header Strict-Transport-Security "max-age=2592000; includeSubdomains";
 
-    location /.well-known {
-      default_type "text/plain";
-      root /var/www/a-know-home/shared/public;
-    }
-
     location / {
       try_files $uri $uri/index.html $uri.html @gg_unicorn;
     }

--- a/site-cookbooks/nginx/templates/default/grass-graph.shitemil.works.conf.erb
+++ b/site-cookbooks/nginx/templates/default/grass-graph.shitemil.works.conf.erb
@@ -5,29 +5,6 @@ upstream gg_unicorn {
 server {
     listen       80;
     server_name  grass-graph.shitemil.works;
-    return 301 https://$host$request_uri;
-}
-
-server {
-    listen       443 ssl;
-    server_name  grass-graph.shitemil.works;
-
-    ssl_certificate /etc/letsencrypt/live/grass-graph.shitemil.works/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/grass-graph.shitemil.works/privkey.pem;
-
-    ssl_session_cache   shared:SSL:3m;
-    ssl_buffer_size     4k;
-    ssl_session_timeout 10m;
-
-    ssl_prefer_server_ciphers on;
-    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-    ssl_ciphers 'ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS';
-
-    # OCSP stapling
-    ssl_stapling on;
-    ssl_stapling_verify on;
-    ssl_trusted_certificate /etc/letsencrypt/live/grass-graph.shitemil.works/fullchain.pem;
-    resolver 8.8.8.8 8.8.4.4 valid=300s;
 
     root /var/www/a-know-home/current/public/gglp;
 

--- a/site-cookbooks/nginx/templates/default/grass-graph.shitemil.works.conf.erb
+++ b/site-cookbooks/nginx/templates/default/grass-graph.shitemil.works.conf.erb
@@ -3,7 +3,7 @@ upstream gg_unicorn {
 }
 
 server {
-    listen       80;
+    listen       80 default_server;
     server_name  grass-graph.shitemil.works;
 
     root /var/www/a-know-home/current/public/gglp;

--- a/site-cookbooks/nginx/templates/default/home.a-know.me.conf.erb
+++ b/site-cookbooks/nginx/templates/default/home.a-know.me.conf.erb
@@ -5,29 +5,6 @@ upstream unicorn {
 server {
     listen       80 default_server;
     server_name  home.a-know.me;
-    return 301 https://$host$request_uri;
-}
-
-server {
-    listen       443 ssl;
-    server_name  home.a-know.me;
-
-    ssl_certificate /etc/letsencrypt/live/home.a-know.me/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/home.a-know.me/privkey.pem;
-
-    ssl_session_cache   shared:SSL:3m;
-    ssl_buffer_size     4k;
-    ssl_session_timeout 10m;
-
-    ssl_prefer_server_ciphers on;
-    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-    ssl_ciphers 'ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS';
-
-    # OCSP stapling
-    ssl_stapling on;
-    ssl_stapling_verify on;
-    ssl_trusted_certificate /etc/letsencrypt/live/home.a-know.me/fullchain.pem;
-    resolver 8.8.8.8 8.8.4.4 valid=300s;
 
     root /var/www/a-know-home/current/public;
 

--- a/site-cookbooks/openssl/recipes/default.rb
+++ b/site-cookbooks/openssl/recipes/default.rb
@@ -16,8 +16,8 @@ bash 'Install openssl-1.0.2h' do
   ./config --prefix=#{dest_dir} shared
   make install
   cp /usr/bin/openssl /usr/bin/openssl.old
-  rm -f /usr/bin/openssl
-  ln -s #{dest_dir}/bin/openssl /usr/bin/openssl
+  sudo rm -f /usr/bin/openssl
+  sudo ln -s #{dest_dir}/bin/openssl /usr/bin/openssl
   EOC
   creates "#{dest_dir}/lib/libssl.so"
 end

--- a/site-cookbooks/td-agent/attributes/default.rb
+++ b/site-cookbooks/td-agent/attributes/default.rb
@@ -1,1 +1,2 @@
 default['mackerel']['apikey'] = nil
+default['instance_kind']['color'] = nil

--- a/site-cookbooks/td-agent/files/default/rails_production_log.conf
+++ b/site-cookbooks/td-agent/files/default/rails_production_log.conf
@@ -1,6 +1,7 @@
 # LTSV形式のログファイルを読み込む
 <source>
   type tail
+  id rails_production_log_tail
   format ltsv
   time_format %Y-%m-%dT%H:%M:%S %z
   path /var/www/a-know-home/shared/log/production.log
@@ -11,25 +12,32 @@
 </source>
 
 <match log.rails>
-  # BigQueryの保存先テーブルを月毎に変化させる
+  # BigQueryの保存先テーブルを日毎に変化させる
   type record_reformer
+  id rails_production_log_reformer
   enable_ruby true
-  tag ${tag}.${time.strftime('%Y%m')}
+  tag ${tag}.${time.strftime('%Y%m%d')}
+
+  <record>
+    hostname ${hostname}
+  </record>
 </match>
 
 <match log.rails.**>
   type forest
   subtype copy
+  id rails_production_log_forest
   <template>
     <store>
       type bigquery
+      id rails_production_log_bigquery
       method insert
 
       auth_method json_key
       json_key /etc/td-agent/.keys/gcp-credential-for-fluentd-jsonkey.json
 
       project a-know-home
-      dataset centrage_rails_log
+      dataset aws_centrage_rails_log
 
       flush_interval 1
       buffer_chunk_records_limit 1000

--- a/site-cookbooks/td-agent/recipes/aws_setting.rb
+++ b/site-cookbooks/td-agent/recipes/aws_setting.rb
@@ -1,0 +1,72 @@
+include_recipe 'td-agent'
+data_bag = Chef::EncryptedDataBagItem.load('webhook_urls', 'knock')
+mackerel_credentials = Chef::EncryptedDataBagItem.load('credentials', 'mackerel')
+color = node[:instance_kind][:color]
+
+%w(
+  fluent-plugin-slack
+  fluent-plugin-mackerel
+  fluent-plugin-forest
+  fluent-plugin-record-reformer
+  fluent-plugin-bigquery
+).each do |gem|
+  gem_package gem do
+    gem_binary '/opt/td-agent/embedded/bin/fluent-gem'
+    notifies :restart, 'service[td-agent]'
+  end
+end
+
+gem_package 'fluent-plugin-datacounter' do
+  gem_binary '/opt/td-agent/embedded/bin/fluent-gem'
+  version '0.5.0'
+  notifies :restart, 'service[td-agent]'
+end
+
+template '/etc/td-agent/td-agent.conf' do
+  variables knock_url: data_bag['slack']
+  source 'td-agent.conf.erb'
+  notifies :restart, 'service[td-agent]'
+end
+
+directory '/etc/td-agent/conf.d'
+
+template '/etc/td-agent/conf.d/admin_shitemil_nginx_access_log.conf' do
+  variables mackerel_api_key: mackerel_credentials['api_key'], mackerel_service_name: 'a-know_shitemil_works', color: color
+  source 'admin_shitemil_nginx_access_log.conf.erb'
+  notifies :restart, 'service[td-agent]'
+end
+
+template '/etc/td-agent/conf.d/grass_graph_nginx_access_log.conf' do
+  variables mackerel_api_key: mackerel_credentials['api_key'], mackerel_service_name: 'grass-graph', color: color
+  source 'grass_graph_nginx_access_log.conf.erb'
+  notifies :restart, 'service[td-agent]'
+end
+
+cookbook_file '/etc/td-agent/conf.d/rails_production_log.conf' do
+  source 'rails_production_log.conf'
+  notifies :restart, 'service[td-agent]'
+end
+
+template '/etc/td-agent/conf.d/bookmark_count.conf' do
+  variables mackerel_api_key_old: mackerel_credentials['api_key_old'], mackerel_service_name_old: 'a-know-home', mackerel_api_key: mackerel_credentials['api_key'], mackerel_service_name: 'blog_a-know_me'
+  source 'bookmark_count.conf.erb'
+  notifies :restart, 'service[td-agent]'
+end
+
+template '/etc/td-agent/conf.d/subscriber_count.conf' do
+  variables mackerel_api_key_old: mackerel_credentials['api_key_old'], mackerel_service_name_old: 'a-know-home', mackerel_api_key: mackerel_credentials['api_key'], mackerel_service_name: 'blog_a-know_me'
+  source 'subscriber_count.conf.erb'
+  notifies :restart, 'service[td-agent]'
+end
+
+template '/etc/td-agent/conf.d/hatena_star_count.conf' do
+  variables mackerel_api_key_old: mackerel_credentials['api_key_old'], mackerel_service_name_old: 'a-know-home', mackerel_api_key: mackerel_credentials['api_key'], mackerel_service_name: 'hatena-status'
+  source 'hatena_star_count.conf.erb'
+  notifies :restart, 'service[td-agent]'
+end
+
+template '/etc/td-agent/conf.d/blog_active_user_number.conf' do
+  variables mackerel_api_key_old: mackerel_credentials['api_key_old'], mackerel_service_name_old: 'a-know-home', mackerel_api_key: mackerel_credentials['api_key'], mackerel_service_name: 'blog_a-know_me'
+  source 'blog_active_user_number.conf.erb'
+  notifies :restart, 'service[td-agent]'
+end

--- a/site-cookbooks/td-agent/recipes/setting.rb
+++ b/site-cookbooks/td-agent/recipes/setting.rb
@@ -6,7 +6,6 @@ mackerel_credentials = Chef::EncryptedDataBagItem.load('credentials', 'mackerel'
 %w(
   fluent-plugin-slack
   fluent-plugin-mackerel
-  fluent-plugin-datacounter
   fluent-plugin-forest
   fluent-plugin-record-reformer
   fluent-plugin-bigquery
@@ -17,6 +16,12 @@ mackerel_credentials = Chef::EncryptedDataBagItem.load('credentials', 'mackerel'
   end
 end
 
+gem_package 'fluent-plugin-datacounter' do
+  gem_binary '/opt/td-agent/embedded/bin/fluent-gem'
+  version '0.5.0'
+  notifies :restart, 'service[td-agent]'
+end
+
 template '/etc/td-agent/td-agent.conf' do
   variables knock_url: data_bag['slack']
   source 'td-agent.conf.erb'
@@ -25,7 +30,7 @@ end
 
 directory '/etc/td-agent/conf.d'
 
-template '/etc/td-agent/conf.d/nginx_access_log.conf' do
+template '/etc/td-agent/conf.d/home_nginx_access_log.conf' do
   variables mackerel_api_key_old: mackerel_credentials['api_key_old'], mackerel_service_name_old: 'a-know-home', mackerel_api_key: mackerel_credentials['api_key'], mackerel_service_name: 'home_a-know_me'
   source 'nginx_access_log.conf.erb'
   notifies :restart, 'service[td-agent]'
@@ -63,11 +68,5 @@ end
 template '/etc/td-agent/conf.d/blog_active_user_number.conf' do
   variables mackerel_api_key_old: mackerel_credentials['api_key_old'], mackerel_service_name_old: 'a-know-home', mackerel_api_key: mackerel_credentials['api_key'], mackerel_service_name: 'blog_a-know_me'
   source 'blog_active_user_number.conf.erb'
-  notifies :restart, 'service[td-agent]'
-end
-
-template '/etc/td-agent/conf.d/a_know_activity.conf' do
-  variables mackerel_api_key_old: mackerel_credentials['api_key_old'], mackerel_service_name_old: 'a-know-home', mackerel_api_key: mackerel_credentials['api_key'], mackerel_service_name: 'myself'
-  source 'a_know_activity.conf.erb'
   notifies :restart, 'service[td-agent]'
 end

--- a/site-cookbooks/td-agent/templates/default/admin_shitemil_nginx_access_log.conf.erb
+++ b/site-cookbooks/td-agent/templates/default/admin_shitemil_nginx_access_log.conf.erb
@@ -1,0 +1,86 @@
+# LTSV形式のログファイルを読み込む
+<source>
+  type tail
+  id admin_shitemil_nginx_access_log_tail
+  format ltsv
+  time_format %Y-%m-%d %H:%M:%S %z
+  path /var/log/nginx/a-know.shitemil.works.access.log
+  read_from_head true
+  rotate_wait 60
+  pos_file /var/log/td-agent/a-know.shitemil.works.access_log.pos
+  tag log.nginx
+</source>
+
+<match log.nginx>
+  type copy
+  id admin_nginx_access_log_copy
+  <store>
+    # BigQueryの保存先テーブルを日毎に変化させる
+    type record_reformer
+    id admin_nginx_access_log_reformer
+    enable_ruby true
+    tag ${tag}.${time.strftime('%Y%m%d')}
+  </store>
+  <store>
+    # fluent-plugin-datacounterでステータスコード別に集計する
+    type datacounter
+    id admin_nginx_access_log_datacounter
+    count_interval 1m
+    count_key status
+    aggregate all
+    tag nginx.status.mackerel
+    pattern1 2xx ^2\d\d$
+    pattern2 3xx ^3\d\d$
+    pattern3 4xx ^4\d\d$
+    pattern4 5xx ^5\d\d$
+  </store>
+</match>
+
+# fluent-plugin-mackerelによりサービスメトリックを投稿する
+<match nginx.status.mackerel>
+  type forest
+  subtype copy
+  id admin_nginx_access_log_forest
+  <template>
+    <store>
+     type mackerel
+     id admin_nginx_access_log_mackerel
+     api_key <%= @mackerel_api_key %>
+     service <%= @mackerel_service_name %>
+     remove_prefix
+     metrics_name <%= @color %>.access_num.${out_key}
+     out_keys 2xx_count,3xx_count,4xx_count,5xx_count
+    </store>
+  </template>
+</match>
+
+<match log.nginx.**>
+  type forest
+  subtype copy
+  id admin_nginx_forest
+  <template>
+    <store>
+      type bigquery
+      id admin_nginx_bigquery
+      method insert
+
+      auth_method json_key
+      json_key /etc/td-agent/.keys/gcp-credential-for-fluentd-jsonkey.json
+
+      project a-know-home
+      dataset aws_centrage_nginx_log
+
+      flush_interval 1
+      buffer_chunk_records_limit 1000
+      buffer_queue_limit 1024
+      num_threads 16
+
+      auto_create_table true
+      table admin_nginx_access_log_${tag_parts[-1]}
+
+      time_format %s
+      time_field time
+      schema_path /etc/td-agent/settings/nginx_access_log_schema.json
+    </store>
+  </template>
+</match>

--- a/site-cookbooks/td-agent/templates/default/blog_active_user_number.conf.erb
+++ b/site-cookbooks/td-agent/templates/default/blog_active_user_number.conf.erb
@@ -1,8 +1,10 @@
 <match blog-metricks.active-visitors>
   type copy
+  id active_visitors_copy
   <store>
     # BigQueryの保存先テーブルを年毎に変化させる
     type record_reformer
+    id active_visitors_reformer
     enable_ruby true
     tag ${tag}.${time.strftime('%Y')}
   </store>
@@ -11,9 +13,11 @@
 <match blog-metricks.active-visitors.**>
   type forest
   subtype copy
+  id active_visitors_forest
   <template>
     <store>
       type bigquery
+      id active_visitors_bigquery
       method insert
 
       auth_method json_key
@@ -36,6 +40,7 @@
     </store>
     <store>
       type mackerel
+      id active_visitors_mackerel_old
       api_key <%= @mackerel_api_key_old %>
       service <%= @mackerel_service_name_old %>
       metrics_name blog-metricks-active-visitors.number
@@ -43,6 +48,7 @@
     </store>
     <store>
       type mackerel
+      id active_visitors_mackerel
       api_key <%= @mackerel_api_key %>
       service <%= @mackerel_service_name %>
       metrics_name active-visitors.number

--- a/site-cookbooks/td-agent/templates/default/bookmark_count.conf.erb
+++ b/site-cookbooks/td-agent/templates/default/bookmark_count.conf.erb
@@ -1,8 +1,10 @@
 <match blog-metricks.bookmark>
   type copy
+  id bookmark_copy
   <store>
     # BigQueryの保存先テーブルを年毎に変化させる
     type record_reformer
+    id bookmark_reformer
     enable_ruby true
     tag ${tag}.${time.strftime('%Y')}
   </store>
@@ -11,9 +13,11 @@
 <match blog-metricks.bookmark.**>
   type forest
   subtype copy
+  id bookmark_forest
   <template>
     <store>
       type bigquery
+      id bookmark_bigquery
       method insert
 
       auth_method json_key
@@ -36,6 +40,7 @@
     </store>
     <store>
       type mackerel
+      id bookmark_mackerel
       api_key <%= @mackerel_api_key_old %>
       service <%= @mackerel_service_name_old %>
       metrics_name blog-metricks-bookmark.total-count
@@ -43,6 +48,7 @@
     </store>
     <store>
       type mackerel
+      id bookmark_mackerel
       api_key <%= @mackerel_api_key %>
       service <%= @mackerel_service_name %>
       metrics_name hatena-bookmark.total-count

--- a/site-cookbooks/td-agent/templates/default/grass_graph_nginx_access_log.conf.erb
+++ b/site-cookbooks/td-agent/templates/default/grass_graph_nginx_access_log.conf.erb
@@ -1,6 +1,7 @@
 # LTSV形式のログファイルを読み込む
 <source>
   type tail
+  id gg_nginx_access_log_tail
   format ltsv
   time_format %Y-%m-%d %H:%M:%S %z
   path /var/log/nginx/grass-graph.shitemil.works.access.log
@@ -12,15 +13,18 @@
 
 <match gg.log.nginx>
   type copy
+  id gg_nginx_access_log_copy
   <store>
     # BigQueryの保存先テーブルを日毎に変化させる
     type record_reformer
+    id gg_nginx_access_reformer
     enable_ruby true
     tag ${tag}.${time.strftime('%Y%m%d')}
   </store>
   <store>
     # fluent-plugin-datacounterでステータスコード別に集計する
     type datacounter
+    id gg_nginx_access_log_datacounter
     count_interval 1m
     count_key status
     aggregate all
@@ -34,41 +38,30 @@
 
 # fluent-plugin-mackerelによりサービスメトリックを投稿する
 <match gg.nginx.status.mackerel>
-  type forest
-  subtype copy
-  <template>
-    <store>
-      type mackerel
-      api_key <%= @mackerel_api_key_old %>
-      service <%= @mackerel_service_name_old %>
-      remove_prefix
-      metrics_name access_num.${out_key}
-      out_keys 2xx_count,3xx_count,4xx_count,5xx_count
-    </store>
-      <store>
-        type mackerel
-        api_key <%= @mackerel_api_key %>
-        service <%= @mackerel_service_name %>
-        remove_prefix
-        metrics_name access_num.${out_key}
-        out_keys 2xx_count,3xx_count,4xx_count,5xx_count
-      </store>
-  </template>
+  type mackerel
+  id gg_nginx_access_log_mackerel
+  api_key <%= @mackerel_api_key %>
+  service <%= @mackerel_service_name %>
+  remove_prefix
+  metrics_name <%= @color %>.access_num.${out_key}
+  out_keys 2xx_count,3xx_count,4xx_count,5xx_count
 </match>
 
 <match gg.log.nginx.**>
   type forest
   subtype copy
+  id gg_log_nginx_forest
   <template>
     <store>
       type bigquery
+      id gg_log_nginx_bigquery
       method insert
 
       auth_method json_key
       json_key /etc/td-agent/.keys/gcp-credential-for-fluentd-jsonkey.json
 
       project a-know-home
-      dataset centrage_nginx_log
+      dataset aws_centrage_nginx_log
 
       flush_interval 1
       buffer_chunk_records_limit 1000

--- a/site-cookbooks/td-agent/templates/default/hatena_star_count.conf.erb
+++ b/site-cookbooks/td-agent/templates/default/hatena_star_count.conf.erb
@@ -1,8 +1,10 @@
 <match blog-metricks.hatena-star>
   type copy
+  id hatena_star_copy
   <store>
     # BigQueryの保存先テーブルを年毎に変化させる
     type record_reformer
+    id hatena_star_reformer
     enable_ruby true
     tag ${tag}.${time.strftime('%Y')}
   </store>
@@ -11,9 +13,11 @@
 <match blog-metricks.hatena-star.**>
   type forest
   subtype copy
+  id hatena_star_forest
   <template>
     <store>
       type bigquery
+      id hatena_star_bigquery
       method insert
 
       auth_method json_key
@@ -36,6 +40,7 @@
     </store>
     <store>
       type mackerel
+      id hatena_star_mackerel_old
       api_key <%= @mackerel_api_key_old %>
       service <%= @mackerel_service_name_old %>
       metrics_name blog-metricks-hatena-star.${out_key}
@@ -43,6 +48,7 @@
     </store>
     <store>
       type mackerel
+      id hatena_star_mackerel
       api_key <%= @mackerel_api_key %>
       service <%= @mackerel_service_name %>
       metrics_name hatena-star.${out_key}

--- a/site-cookbooks/td-agent/templates/default/nginx_access_log.conf.erb
+++ b/site-cookbooks/td-agent/templates/default/nginx_access_log.conf.erb
@@ -1,6 +1,7 @@
 # LTSV形式のログファイルを読み込む
 <source>
   type tail
+  id home_nginx_access_log_tail
   format ltsv
   time_format %Y-%m-%d %H:%M:%S %z
   path /var/log/nginx/home.a-know.me.access.log
@@ -12,63 +13,71 @@
 
 <match log.nginx>
   type copy
+  id home_nginx_access_log_copy
   <store>
-    # BigQueryの保存先テーブルを月毎に変化させる
+    # BigQueryの保存先テーブルを日毎に変化させる
     type record_reformer
+    id home_nginx_access_log_reformer
     enable_ruby true
-    tag ${tag}.${time.strftime('%Y%m')}
+    tag ${tag}.${time.strftime('%Y%m%d')}
   </store>
-  <store>
-    # fluent-plugin-datacounterでステータスコード別に集計する
-    type datacounter
-    count_interval 1m
-    count_key status
-    aggregate all
-    tag nginx.status.mackerel
-    pattern1 2xx ^2\d\d$
-    pattern2 3xx ^3\d\d$
-    pattern3 4xx ^4\d\d$
-    pattern4 5xx ^5\d\d$
-  </store>
+#  <store>
+#    # fluent-plugin-datacounterでステータスコード別に集計する
+#    type datacounter
+#    id home_nginx_access_log_datacounter
+#    count_interval 1m
+#    count_key status
+#    aggregate all
+#    tag nginx.status.mackerel
+#    pattern1 2xx ^2\d\d$
+#    pattern2 3xx ^3\d\d$
+#    pattern3 4xx ^4\d\d$
+#    pattern4 5xx ^5\d\d$
+#  </store>
 </match>
 
 # fluent-plugin-mackerelによりサービスメトリックを投稿する
-<match nginx.status.mackerel>
-  type forest
-  subtype copy
-  <template>
-    <store>
-      type mackerel
-      api_key <%= @mackerel_api_key_old %>
-      service <%= @mackerel_service_name_old %>
-      remove_prefix
-      metrics_name access_num.${out_key}
-      out_keys 2xx_count,3xx_count,4xx_count,5xx_count
-    </store>
-      <store>
-        type mackerel
-        api_key <%= @mackerel_api_key %>
-        service <%= @mackerel_service_name %>
-        remove_prefix
-        metrics_name access_num.${out_key}
-        out_keys 2xx_count,3xx_count,4xx_count,5xx_count
-      </store>
-  </template>
-</match>
+# <match nginx.status.mackerel>
+#   type forest
+#   subtype copy
+#   id home_nginx_access_log_forest
+#   <template>
+#     <store>
+#       type mackerel
+#       id home_nginx_access_log_mackerel_old
+#       api_key <%= @mackerel_api_key_old %>
+#       service <%= @mackerel_service_name_old %>
+#       remove_prefix
+#       metrics_name access_num.${out_key}
+#       out_keys 2xx_count,3xx_count,4xx_count,5xx_count
+#     </store>
+#       <store>
+#         type mackerel
+#         id home_nginx_access_log_mackerel
+#         api_key <%= @mackerel_api_key %>
+#         service <%= @mackerel_service_name %>
+#         remove_prefix
+#         metrics_name access_num.${out_key}
+#         out_keys 2xx_count,3xx_count,4xx_count,5xx_count
+#       </store>
+#   </template>
+# </match>
 
 <match log.nginx.**>
   type forest
   subtype copy
+  id home_nginx_forest
   <template>
     <store>
       type bigquery
+      id home_nginx_bigquery
       method insert
 
       auth_method json_key
       json_key /etc/td-agent/.keys/gcp-credential-for-fluentd-jsonkey.json
 
       project a-know-home
-      dataset centrage_nginx_log
+      dataset aws_centrage_nginx_log
 
       flush_interval 1
       buffer_chunk_records_limit 1000
@@ -76,7 +85,7 @@
       num_threads 16
 
       auto_create_table true
-      table nginx_access_log_${tag_parts[-1]}
+      table home_nginx_access_log_${tag_parts[-1]}
 
       time_format %s
       time_field time

--- a/site-cookbooks/td-agent/templates/default/subscriber_count.conf.erb
+++ b/site-cookbooks/td-agent/templates/default/subscriber_count.conf.erb
@@ -1,8 +1,10 @@
 <match blog-metricks.subscribers>
   type copy
+  id subscribers_copy
   <store>
     # BigQueryの保存先テーブルを年毎に変化させる
     type record_reformer
+    id subscribers_reformer
     enable_ruby true
     tag ${tag}.${time.strftime('%Y')}
   </store>
@@ -11,9 +13,11 @@
 <match blog-metricks.subscribers.**>
   type forest
   subtype copy
+  id subscribers_forest
   <template>
     <store>
       type bigquery
+      id subscribers_bigquery
       method insert
 
       auth_method json_key
@@ -36,6 +40,7 @@
     </store>
     <store>
       type mackerel
+      id subscribers_mackerel_old
       api_key <%= @mackerel_api_key_old %>
       service <%= @mackerel_service_name_old %>
       metrics_name blog-metricks-subscribers.${out_key}
@@ -43,6 +48,7 @@
     </store>
     <store>
       type mackerel
+      id subscribers_mackerel
       api_key <%= @mackerel_api_key %>
       service <%= @mackerel_service_name %>
       metrics_name subscribers.${out_key}

--- a/site-cookbooks/td-agent/templates/default/td-agent.conf.erb
+++ b/site-cookbooks/td-agent/templates/default/td-agent.conf.erb
@@ -1,15 +1,18 @@
 <source>
   type monitor_agent
+  id monitor_agent_input
   bind 0.0.0.0
   port 24220
 </source>
 
 <source>
   type forward
+  id source_forward
 </source>
 
 <match knock.slack>
   type slack
+  id knock_slack
   webhook_url <%= @knock_url %>
   channel a-know-home-notify
   username VisitorNotification

--- a/site-cookbooks/users/recipes/default.rb
+++ b/site-cookbooks/users/recipes/default.rb
@@ -17,6 +17,8 @@ data_ids.each do |id|
   end
 
   directory u['home'] do
+    owner u['uid']
+    group u['gid']
     mode 0755
     action :create
   end

--- a/spec/roles/aws_ci_spec.rb
+++ b/spec/roles/aws_ci_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe 'web' do
+  # aws-base
+  it_behaves_like 'sudoers'
+  it_behaves_like 'users'
+  # aws-middleware
+  it_behaves_like 'chrony'
+  it_behaves_like 'firewalld::disable'
+  it_behaves_like 'gcc'
+  it_behaves_like 'git'
+  it_behaves_like 'hostname'
+  it_behaves_like 'imagemagick'
+  it_behaves_like 'logrotate'
+  it_behaves_like 'mkr'
+  it_behaves_like 'net-tools'
+  it_behaves_like 'openssh'
+  it_behaves_like 'openssl'
+  it_behaves_like 'openssl-devel'
+  it_behaves_like 'patch'
+  it_behaves_like 'ruby'
+  it_behaves_like 'selinux'
+  it_behaves_like 'sysstat'
+  it_behaves_like 'timezone'
+  it_behaves_like 'zlib'
+  # aws-application
+  it_behaves_like 'bigquery::settings'
+  it_behaves_like 'nginx::aws'
+  it_behaves_like 'td-agent'
+  # aws-prod
+  it_behaves_like 'crond'
+end

--- a/spec/roles/aws_prod_spec.rb
+++ b/spec/roles/aws_prod_spec.rb
@@ -30,4 +30,5 @@ describe 'web' do
   # aws-prod
   it_behaves_like 'crond'
   it_behaves_like 'crontab'
+  it_behaves_like 'mackerel'
 end

--- a/spec/roles/aws_prod_spec.rb
+++ b/spec/roles/aws_prod_spec.rb
@@ -6,5 +6,6 @@ describe 'web' do
   it_behaves_like 'users'
   # aws-middleware
   it_behaves_like 'chrony'
+  it_behaves_like 'firewalld::disable'
 
 end

--- a/spec/roles/aws_prod_spec.rb
+++ b/spec/roles/aws_prod_spec.rb
@@ -10,5 +10,6 @@ describe 'web' do
   it_behaves_like 'gcc'
   it_behaves_like 'git'
   it_behaves_like 'hostname'
+  it_behaves_like 'imagemagick'
 
 end

--- a/spec/roles/aws_prod_spec.rb
+++ b/spec/roles/aws_prod_spec.rb
@@ -12,5 +12,12 @@ describe 'web' do
   it_behaves_like 'hostname'
   it_behaves_like 'imagemagick'
   it_behaves_like 'logrotate'
+  it_behaves_like 'mkr'
+  it_behaves_like 'net-tools'
+  it_behaves_like 'openssh'
+  it_behaves_like 'openssl'
+  it_behaves_like 'openssl-devel'
+  it_behaves_like 'patch'
+  it_behaves_like 'ruby'
 
 end

--- a/spec/roles/aws_prod_spec.rb
+++ b/spec/roles/aws_prod_spec.rb
@@ -21,5 +21,6 @@ describe 'web' do
   it_behaves_like 'ruby'
   it_behaves_like 'selinux'
   it_behaves_like 'sysstat'
+  it_behaves_like 'timezone'
 
 end

--- a/spec/roles/aws_prod_spec.rb
+++ b/spec/roles/aws_prod_spec.rb
@@ -7,5 +7,7 @@ describe 'web' do
   # aws-middleware
   it_behaves_like 'chrony'
   it_behaves_like 'firewalld::disable'
+  it_behaves_like 'gcc'
+  it_behaves_like 'git'
 
 end

--- a/spec/roles/aws_prod_spec.rb
+++ b/spec/roles/aws_prod_spec.rb
@@ -9,5 +9,6 @@ describe 'web' do
   it_behaves_like 'firewalld::disable'
   it_behaves_like 'gcc'
   it_behaves_like 'git'
+  it_behaves_like 'hostname'
 
 end

--- a/spec/roles/aws_prod_spec.rb
+++ b/spec/roles/aws_prod_spec.rb
@@ -4,4 +4,7 @@ describe 'web' do
   # aws-base
   it_behaves_like 'sudoers'
   it_behaves_like 'users'
+  # aws-middleware
+  it_behaves_like 'chrony'
+
 end

--- a/spec/roles/aws_prod_spec.rb
+++ b/spec/roles/aws_prod_spec.rb
@@ -11,5 +11,6 @@ describe 'web' do
   it_behaves_like 'git'
   it_behaves_like 'hostname'
   it_behaves_like 'imagemagick'
+  it_behaves_like 'logrotate'
 
 end

--- a/spec/roles/aws_prod_spec.rb
+++ b/spec/roles/aws_prod_spec.rb
@@ -22,5 +22,6 @@ describe 'web' do
   it_behaves_like 'selinux'
   it_behaves_like 'sysstat'
   it_behaves_like 'timezone'
+  it_behaves_like 'zlib'
 
 end

--- a/spec/roles/aws_prod_spec.rb
+++ b/spec/roles/aws_prod_spec.rb
@@ -23,5 +23,7 @@ describe 'web' do
   it_behaves_like 'sysstat'
   it_behaves_like 'timezone'
   it_behaves_like 'zlib'
+  # aws-application
+  it_behaves_like 'bigquery::settings'
 
 end

--- a/spec/roles/aws_prod_spec.rb
+++ b/spec/roles/aws_prod_spec.rb
@@ -20,5 +20,6 @@ describe 'web' do
   it_behaves_like 'patch'
   it_behaves_like 'ruby'
   it_behaves_like 'selinux'
+  it_behaves_like 'sysstat'
 
 end

--- a/spec/roles/aws_prod_spec.rb
+++ b/spec/roles/aws_prod_spec.rb
@@ -31,4 +31,5 @@ describe 'web' do
   it_behaves_like 'crond'
   it_behaves_like 'crontab'
   it_behaves_like 'mackerel'
+  it_behaves_like 'mkswap'
 end

--- a/spec/roles/aws_prod_spec.rb
+++ b/spec/roles/aws_prod_spec.rb
@@ -25,5 +25,6 @@ describe 'web' do
   it_behaves_like 'zlib'
   # aws-application
   it_behaves_like 'bigquery::settings'
+  it_behaves_like 'nginx::aws'
 
 end

--- a/spec/roles/aws_prod_spec.rb
+++ b/spec/roles/aws_prod_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
 describe 'web' do
+  # aws-base
   it_behaves_like 'sudoers'
+  it_behaves_like 'users'
 end

--- a/spec/roles/aws_prod_spec.rb
+++ b/spec/roles/aws_prod_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe 'web' do
+  it_behaves_like 'sudoers'
+end

--- a/spec/roles/aws_prod_spec.rb
+++ b/spec/roles/aws_prod_spec.rb
@@ -26,5 +26,6 @@ describe 'web' do
   # aws-application
   it_behaves_like 'bigquery::settings'
   it_behaves_like 'nginx::aws'
+  it_behaves_like 'td-agent'
 
 end

--- a/spec/roles/aws_prod_spec.rb
+++ b/spec/roles/aws_prod_spec.rb
@@ -27,5 +27,7 @@ describe 'web' do
   it_behaves_like 'bigquery::settings'
   it_behaves_like 'nginx::aws'
   it_behaves_like 'td-agent'
-
+  # aws-prod
+  it_behaves_like 'crond'
+  it_behaves_like 'crontab'
 end

--- a/spec/roles/aws_prod_spec.rb
+++ b/spec/roles/aws_prod_spec.rb
@@ -19,5 +19,6 @@ describe 'web' do
   it_behaves_like 'openssl-devel'
   it_behaves_like 'patch'
   it_behaves_like 'ruby'
+  it_behaves_like 'selinux'
 
 end

--- a/spec/shared/bigquery.rb
+++ b/spec/shared/bigquery.rb
@@ -13,41 +13,43 @@ shared_examples 'bigquery::settings' do
     it { should be_owned_by 'root' }
     it { should be_grouped_into 'root' }
     it { should be_mode 644 }
+    its(:content) { should include "id" }
+    its(:content) { should include "hostname" }
   end
   describe file '/etc/td-agent/settings/rails_production_log_schema.json' do
     it { should be_file }
     it { should be_owned_by 'root' }
     it { should be_grouped_into 'root' }
     it { should be_mode 644 }
+    its(:content) { should include "id" }
+    its(:content) { should include "hostname" }
   end
   describe file '/etc/td-agent/settings/bookmark_count_schema.json' do
     it { should be_file }
     it { should be_owned_by 'root' }
     it { should be_grouped_into 'root' }
     it { should be_mode 644 }
+    its(:content) { should include "id" }
   end
   describe file '/etc/td-agent/settings/subscribers_count_schema.json' do
     it { should be_file }
     it { should be_owned_by 'root' }
     it { should be_grouped_into 'root' }
     it { should be_mode 644 }
+    its(:content) { should include "id" }
   end
   describe file '/etc/td-agent/settings/hatena_star_count_schema.json' do
     it { should be_file }
     it { should be_owned_by 'root' }
     it { should be_grouped_into 'root' }
     it { should be_mode 644 }
+    its(:content) { should include "id" }
   end
   describe file '/etc/td-agent/settings/active_visitors_count_schema.json' do
     it { should be_file }
     it { should be_owned_by 'root' }
     it { should be_grouped_into 'root' }
     it { should be_mode 644 }
-  end
-  describe file '/etc/td-agent/settings/steps_schema.json' do
-    it { should be_file }
-    it { should be_owned_by 'root' }
-    it { should be_grouped_into 'root' }
-    it { should be_mode 644 }
+    its(:content) { should include "id" }
   end
 end

--- a/spec/shared/crond.rb
+++ b/spec/shared/crond.rb
@@ -1,0 +1,6 @@
+shared_examples 'crond' do
+  describe service 'crond' do
+    it { should be_enabled }
+    it { should be_running }
+  end
+end

--- a/spec/shared/crontab.rb
+++ b/spec/shared/crontab.rb
@@ -1,7 +1,6 @@
 shared_examples 'crontab' do
   describe cron do
-    it { should have_entry('00 4 25 * * /usr/local/bin/certbot/certbot-auto certonly --webroot -w /var/www/a-know-home/shared/public -d a-know.me --renew-by-default --non-interactive && sudo nginx -s reload').with_user('root') }
-    it { should have_entry('00 4 15 * * /usr/local/bin/certbot/certbot-auto certonly --webroot -w /var/www/a-know-home/shared/public -d home.a-know.me --renew-by-default --non-interactive && sudo nginx -s reload').with_user('root') }
-    it { should have_entry('00 4 10 * * /usr/local/bin/certbot/certbot-auto certonly --webroot -w /var/www/a-know-home/shared/public -d grass-graph.shitemil.works --renew-by-default --non-interactive && sudo nginx -s reload').with_user('root') }
+    echo_cmd = 'echo -e "grass-graph.images.count\t$(ls -1 /var/www/a-know-home/shared/tmp/gg_others_svg/${d} | wc -l)\t$(date -u +\\%s)"'
+    it { should have_entry("*/15 * * * * export MACKEREL_APIKEY=#{ENV['NEW_MACKEREL_APIKEY']} && d=`date '+\\%Y-\\%m-\\%d'` && #{echo_cmd} | /usr/local/bin/mkr throw --service grass-graph").with_user('root') }
   end
 end

--- a/spec/shared/hostname.rb
+++ b/spec/shared/hostname.rb
@@ -1,6 +1,6 @@
 shared_examples 'hostname' do
   describe file '/etc/hostname' do
-    its(:content) { should include 'centrage' }
+    its(:content) { should match /blue\d+|green\d+/ }
   end
 
   describe file '/etc/profile.d/network.sh' do

--- a/spec/shared/logrotate.rb
+++ b/spec/shared/logrotate.rb
@@ -1,4 +1,8 @@
 shared_examples 'logrotate' do
+  describe package 'logrotate' do
+    it { should be_installed }
+  end
+
   describe file '/etc/logrotate.d/app' do
     it { should be_file }
     it { should be_owned_by 'root' }

--- a/spec/shared/nginx.rb
+++ b/spec/shared/nginx.rb
@@ -53,3 +53,54 @@ shared_examples 'nginx' do
     its(:content) { should include 'rotate 10' }
   end
 end
+
+shared_examples 'nginx::aws' do
+  describe service 'nginx' do
+    it { should be_enabled }
+    it { should be_running }
+  end
+
+  describe file '/etc/nginx/nginx.conf' do
+    it { should be_file }
+    it { should be_owned_by 'root' }
+    it { should be_grouped_into 'root' }
+    it { should be_mode 644 }
+    its(:content) { should match /open_file_cache .+;/ }
+    its(:content) { should include '"\thostname:$hostname";' }
+    its(:content) { should include 'open_file_cache_errors on;' }
+    its(:content) { should include 'location /nginx_status' }
+    its(:content) { should include 'stub_status on' }
+  end
+
+  describe command('curl http://localhost:8080/nginx_status') do
+    its(:stdout) { should include 'Active connections' }
+  end
+
+  describe file '/etc/nginx/conf.d/a-know.shitemil.works.conf' do
+    it { should be_file }
+    it { should be_owned_by 'root' }
+    it { should be_grouped_into 'root' }
+    it { should be_mode 644 }
+    its(:content) { should include 'server_name  a-know.shitemil.works;' }
+    its(:content) { should include 'set_real_ip_from 10.0.0.0/8;' }
+    its(:content) { should include 'rewrite ^(.*)$ https://home.a-know.me/ redirect;' }
+  end
+
+  describe file '/etc/nginx/conf.d/grass-graph.shitemil.works.conf' do
+    it { should be_file }
+    it { should be_owned_by 'root' }
+    it { should be_grouped_into 'root' }
+    it { should be_mode 644 }
+    its(:content) { should match /listen\s+80 default_server;/ } # default server
+    its(:content) { should include 'grass-graph.shitemil.works' }
+    its(:content) { should include 'add_header Strict-Transport-Security "max-age=2592000; includeSubdomains"' }
+  end
+
+  describe file '/etc/logrotate.d/nginx' do
+    it { should be_file }
+    it { should be_owned_by 'root' }
+    it { should be_grouped_into 'root' }
+    it { should be_mode 644 }
+    its(:content) { should include 'rotate 10' }
+  end
+end

--- a/spec/shared/td-agent.rb
+++ b/spec/shared/td-agent.rb
@@ -22,12 +22,6 @@ shared_examples 'td-agent' do
     its(:content) { should include 'service grass-graph' }
   end
 
-  describe file '/etc/td-agent/conf.d/nginx_access_log.conf' do
-    it { should be_owned_by 'root' }
-    it { should be_grouped_into 'root' }
-    it { should be_mode 644 }
-  end
-
   describe file '/etc/td-agent/conf.d/rails_production_log.conf' do
     it { should be_owned_by 'root' }
     it { should be_grouped_into 'root' }
@@ -58,12 +52,6 @@ shared_examples 'td-agent' do
     it { should be_mode 644 }
   end
 
-  describe file '/etc/td-agent/conf.d/a_know_activity.conf' do
-    it { should be_owned_by 'root' }
-    it { should be_grouped_into 'root' }
-    it { should be_mode 644 }
-  end
-
   describe 'Plugins' do
     let(:path) { "/opt/td-agent/embedded/bin:#{ENV['PATH']}" }
     describe package 'fluent-plugin-slack' do
@@ -75,7 +63,7 @@ shared_examples 'td-agent' do
     end
 
     describe package 'fluent-plugin-datacounter' do
-      it { should be_installed.by('gem') }
+      it { should be_installed.by('gem').with_version('0.5.0') }
     end
 
     describe package 'fluent-plugin-forest' do


### PR DESCRIPTION
* CloudFormation の使用
* 出力ログに hostname を追加
    * 複数サーバからのログを一箇所（BigQuery）に集約するため
* ELB の利用
    * SSL の処理を ELB に集約
* fluentd plugin に id を指定
* fluentd 0.14.x 系への対策
* mackerel-agent 起動時の段階でロールに所属させる
* 古い mackerel org への投稿を一部停止
* 新たな BQ dataset の作成
* ELB への SSL 証明書のセット（手作業）
* grass-graph.shitemil.works a-know.shitemil.works 2つのドメインをホストする前提での準備
    * APIは a-know.shitemil.works に集約
* 一部サービスメトリックはホストごとに投稿できるように
* AWS 用のノードやロールを作成
* ELB に複数インスタンスをアタッチ
* Mackerel デフォルトロール・サービスを変更
* ELBを経由してもリクエスト元のIPを保持できるように
* home.a-know.me を自前でホストするのをやめる
* SSL証明書の生成を Let's Encrypt を使うのをやめて ACM を使うようにする
* serverspec の整備
* ci 環境の整備